### PR TITLE
Add test suite, pre-commit hook, and build-time link checker

### DIFF
--- a/__tests__/contact-form-schema.test.js
+++ b/__tests__/contact-form-schema.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { formSchema, MAX_CHARS, RESPONSE_OPTIONS } from '../components/forms/contactFormSchema'
+
+// Helper to parse with the schema and return success/error
+const parse = (data) => formSchema.safeParse(data)
+
+// Base valid data for tests
+const validBase = {
+  message: 'Hello, this is a test message.',
+  responseType: 'none',
+  email: '',
+  signalUsername: '',
+  signalPhone: '',
+}
+
+describe('Contact form schema', () => {
+  describe('constants', () => {
+    it('MAX_CHARS is 5000', () => {
+      expect(MAX_CHARS).toBe(5000)
+    })
+
+    it('RESPONSE_OPTIONS has 4 options', () => {
+      expect(RESPONSE_OPTIONS).toHaveLength(4)
+    })
+
+    it('RESPONSE_OPTIONS values are none, signal_username, signal_phone, email', () => {
+      const values = RESPONSE_OPTIONS.map(o => o.value)
+      expect(values).toEqual(['none', 'signal_username', 'signal_phone', 'email'])
+    })
+  })
+
+  describe('message validation', () => {
+    it('rejects empty message', () => {
+      const result = parse({ ...validBase, message: '' })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts valid message', () => {
+      const result = parse(validBase)
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects message exceeding MAX_CHARS', () => {
+      const result = parse({ ...validBase, message: 'a'.repeat(MAX_CHARS + 1) })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts message at exactly MAX_CHARS', () => {
+      const result = parse({ ...validBase, message: 'a'.repeat(MAX_CHARS) })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('responseType validation', () => {
+    it('accepts all valid response types', () => {
+      for (const opt of RESPONSE_OPTIONS) {
+        const data = { ...validBase, responseType: opt.value }
+        // For non-'none' types, provide the required contact info
+        if (opt.value === 'email') data.email = 'test@example.com'
+        if (opt.value === 'signal_username') data.signalUsername = 'testuser.12'
+        if (opt.value === 'signal_phone') data.signalPhone = '+15551234567'
+
+        const result = parse(data)
+        expect(result.success, `responseType '${opt.value}' should be valid`).toBe(true)
+      }
+    })
+
+    it('rejects invalid response type', () => {
+      const result = parse({ ...validBase, responseType: 'telegram' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('email validation', () => {
+    it('accepts valid email when responseType is email', () => {
+      const result = parse({ ...validBase, responseType: 'email', email: 'user@example.com' })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects invalid email format', () => {
+      const result = parse({ ...validBase, responseType: 'email', email: 'not-an-email' })
+      expect(result.success).toBe(false)
+    })
+
+    it('fails cross-field validation when email is empty but responseType is email', () => {
+      const result = parse({ ...validBase, responseType: 'email', email: '' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('signal username validation', () => {
+    it('accepts valid username like snowden.04', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: 'snowden.04' })
+      expect(result.success).toBe(true)
+    })
+
+    it('strips @ prefix and lowercases', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: '@Snowden.04' })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.signalUsername).toBe('@snowden.04')
+      }
+    })
+
+    it('rejects usernames shorter than 3 characters', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: 'ab' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects usernames with invalid characters', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: 'user name!.04' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects usernames not ending with .NN', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: 'snowden' })
+      expect(result.success).toBe(false)
+    })
+
+    it('fails cross-field validation when username is empty but responseType is signal_username', () => {
+      const result = parse({ ...validBase, responseType: 'signal_username', signalUsername: '' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('signal phone validation', () => {
+    it('accepts phone number when responseType is signal_phone', () => {
+      const result = parse({ ...validBase, responseType: 'signal_phone', signalPhone: '+15551234567' })
+      expect(result.success).toBe(true)
+    })
+
+    it('fails cross-field validation when phone is empty but responseType is signal_phone', () => {
+      const result = parse({ ...validBase, responseType: 'signal_phone', signalPhone: '' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('cross-field validation', () => {
+    it('passes when responseType is none with no contact info', () => {
+      const result = parse(validBase)
+      expect(result.success).toBe(true)
+    })
+
+    it('allows empty contact fields when responseType is none', () => {
+      const result = parse({
+        message: 'test',
+        responseType: 'none',
+        email: '',
+        signalUsername: '',
+        signalPhone: '',
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { slugify, truncateText, renderRichTextTreeAsPlainText } from '../utils/core'
+
+describe('slugify', () => {
+  it('converts basic text to slug', () => {
+    expect(slugify('Hello World')).toBe('hello-world')
+  })
+
+  it('removes special characters', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world')
+  })
+
+  it('collapses multiple spaces into single dash', () => {
+    expect(slugify('Hello   World')).toBe('hello-world')
+  })
+
+  it('trims leading and trailing dashes', () => {
+    expect(slugify('-hello-world-')).toBe('hello-world')
+  })
+
+  it('handles numbers', () => {
+    expect(slugify('Step 1: Do this')).toBe('step-1-do-this')
+  })
+
+  it('respects maxLength config', () => {
+    const result = slugify('hello beautiful world', { maxLength: 8 })
+    expect(result.length).toBeLessThanOrEqual(8)
+  })
+
+  it('respects maxWords config', () => {
+    expect(slugify('hello beautiful world', { maxWords: 2 })).toBe('hello-beautiful')
+  })
+
+  it('handles empty string', () => {
+    expect(slugify('')).toBe('')
+  })
+
+  it('handles strings with only special characters', () => {
+    expect(slugify('!@#$%')).toBe('')
+  })
+})
+
+describe('truncateText', () => {
+  it('returns empty string for null', () => {
+    expect(truncateText(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(truncateText(undefined)).toBe('')
+  })
+
+  it('returns empty string for empty string', () => {
+    expect(truncateText('')).toBe('')
+  })
+
+  it('returns original text when shorter than maxLength', () => {
+    expect(truncateText('short text')).toBe('short text')
+  })
+
+  it('truncates and adds ellipsis when exceeding default maxLength', () => {
+    const longText = 'a'.repeat(200)
+    const result = truncateText(longText)
+    expect(result.length).toBeLessThanOrEqual(153) // 150 + '...'
+    expect(result).toMatch(/\.\.\.$/u)
+  })
+
+  it('respects custom maxLength', () => {
+    const result = truncateText('hello world', 5)
+    expect(result).toBe('hello...')
+  })
+
+  it('returns text exactly at maxLength without truncation', () => {
+    const text = 'a'.repeat(150)
+    expect(truncateText(text)).toBe(text)
+  })
+})
+
+describe('renderRichTextTreeAsPlainText', () => {
+  it('returns empty string for null', () => {
+    expect(renderRichTextTreeAsPlainText(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(renderRichTextTreeAsPlainText(undefined)).toBe('')
+  })
+
+  it('extracts text from a text node', () => {
+    expect(renderRichTextTreeAsPlainText({ type: 'text', text: 'hello' })).toBe('hello')
+  })
+
+  it('recursively processes content arrays', () => {
+    const tree = {
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' }
+      ]
+    }
+    expect(renderRichTextTreeAsPlainText(tree)).toBe('hello world')
+  })
+
+  it('handles doc type', () => {
+    const tree = {
+      type: 'doc',
+      content: [
+        {
+          content: [
+            { type: 'text', text: 'paragraph text' }
+          ]
+        }
+      ]
+    }
+    expect(renderRichTextTreeAsPlainText(tree)).toBe('paragraph text')
+  })
+
+  it('handles nested content', () => {
+    const tree = {
+      type: 'doc',
+      content: [
+        {
+          content: [
+            { type: 'text', text: 'first' }
+          ]
+        },
+        {
+          content: [
+            { type: 'text', text: 'second' }
+          ]
+        }
+      ]
+    }
+    expect(renderRichTextTreeAsPlainText(tree)).toBe('first second')
+  })
+
+  it('filters empty strings from output', () => {
+    const tree = {
+      content: [
+        { type: 'text', text: '' },
+        { type: 'text', text: 'hello' }
+      ]
+    }
+    // Empty text returns '', which gets filtered
+    expect(renderRichTextTreeAsPlainText(tree)).toBe('hello')
+  })
+})

--- a/__tests__/imageLoader.test.js
+++ b/__tests__/imageLoader.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import imageLoader from '../utils/imageLoader'
+
+describe('imageLoader', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  describe('development mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('returns src with width and quality params', () => {
+      const result = imageLoader({ src: 'https://a.storyblok.com/f/123/test.png', width: 800, quality: 90 })
+      expect(result).toBe('https://a.storyblok.com/f/123/test.png?w=800&q=90')
+    })
+
+    it('uses default quality of 75 when not specified', () => {
+      const result = imageLoader({ src: 'https://a.storyblok.com/f/123/test.png', width: 600 })
+      expect(result).toBe('https://a.storyblok.com/f/123/test.png?w=600&q=75')
+    })
+  })
+
+  describe('production mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    it('extracts filename and prefixes with /images/', () => {
+      const result = imageLoader({ src: 'https://a.storyblok.com/f/123/abc/test.png', width: 800 })
+      expect(result).toBe('/images/test.png')
+    })
+
+    it('handles URLs with complex paths', () => {
+      const result = imageLoader({ src: 'https://a.storyblok.com/f/123/abc/def/image-file.jpg', width: 400 })
+      expect(result).toBe('/images/image-file.jpg')
+    })
+
+    it('handles local image paths', () => {
+      const result = imageLoader({ src: '/images/logo.png', width: 200 })
+      expect(result).toBe('/images/logo.png')
+    })
+  })
+})

--- a/__tests__/lib-utils.test.js
+++ b/__tests__/lib-utils.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { cn, formatRelativeDate } from '../lib/utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles conditional classes', () => {
+    expect(cn('foo', false && 'bar', 'baz')).toBe('foo baz')
+  })
+
+  it('handles undefined and null', () => {
+    expect(cn('foo', undefined, null, 'bar')).toBe('foo bar')
+  })
+
+  it('resolves conflicting Tailwind classes', () => {
+    // tailwind-merge should keep the last conflicting class
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+  })
+
+  it('resolves conflicting Tailwind padding classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  it('merges non-conflicting Tailwind classes', () => {
+    expect(cn('px-2', 'py-4')).toBe('px-2 py-4')
+  })
+
+  it('handles empty input', () => {
+    expect(cn()).toBe('')
+  })
+})
+
+describe('formatRelativeDate', () => {
+  it('returns empty string for falsy input', () => {
+    expect(formatRelativeDate(null)).toBe('')
+    expect(formatRelativeDate(undefined)).toBe('')
+    expect(formatRelativeDate('')).toBe('')
+  })
+
+  it('returns "Today" for today\'s date', () => {
+    const today = new Date()
+    expect(formatRelativeDate(today.toISOString())).toBe('Today')
+  })
+
+  it('returns "Yesterday" for yesterday\'s date', () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    expect(formatRelativeDate(yesterday.toISOString())).toBe('Yesterday')
+  })
+
+  it('returns "N days ago" for 2-7 days ago', () => {
+    const threeDaysAgo = new Date()
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
+    expect(formatRelativeDate(threeDaysAgo.toISOString())).toBe('3 days ago')
+  })
+
+  it('returns formatted date for dates older than 7 days', () => {
+    const twoWeeksAgo = new Date()
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14)
+    const result = formatRelativeDate(twoWeeksAgo.toISOString())
+    // Should be "Mon DD" format (e.g. "Jan 15")
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2}/)
+  })
+
+  it('includes year for dates from a different year', () => {
+    const oldDate = new Date('2020-06-15T12:00:00Z')
+    const result = formatRelativeDate(oldDate.toISOString())
+    // Should include the year
+    expect(result).toContain('2020')
+  })
+})

--- a/__tests__/link.test.js
+++ b/__tests__/link.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+
+// Test the link classification logic used in components/Link.js
+// Extracted as a pure function to avoid needing React/jsdom
+const isExternalLink = (href) => typeof href === 'string' && href.startsWith('http')
+
+describe('Link classification logic', () => {
+  it('identifies HTTPS links as external', () => {
+    expect(isExternalLink('https://example.com')).toBe(true)
+  })
+
+  it('identifies HTTP links as external', () => {
+    expect(isExternalLink('http://example.com')).toBe(true)
+  })
+
+  it('identifies absolute paths as internal', () => {
+    expect(isExternalLink('/about')).toBe(false)
+  })
+
+  it('identifies relative paths as internal', () => {
+    expect(isExternalLink('about')).toBe(false)
+  })
+
+  it('identifies anchor links as internal', () => {
+    expect(isExternalLink('#section')).toBe(false)
+  })
+
+  it('handles undefined gracefully', () => {
+    expect(isExternalLink(undefined)).toBe(false)
+  })
+
+  it('handles null gracefully', () => {
+    expect(isExternalLink(null)).toBe(false)
+  })
+
+  it('handles empty string', () => {
+    expect(isExternalLink('')).toBe(false)
+  })
+
+  it('handles non-string values', () => {
+    expect(isExternalLink(42)).toBe(false)
+    expect(isExternalLink({})).toBe(false)
+  })
+})

--- a/__tests__/navigation.test.js
+++ b/__tests__/navigation.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNavItemActive,
+  findActiveSection,
+  isSubItemActive,
+  navigationConfig,
+  footerConfig,
+  SECURITY_CHECKLISTS,
+  SOCIAL_LINKS,
+  NAV_ITEMS,
+} from '../config/navigation'
+
+describe('isNavItemActive', () => {
+  it('returns false for items with hash href', () => {
+    expect(isNavItemActive({ href: '#section', type: 'link' }, '/about')).toBe(false)
+  })
+
+  it('returns true for link-type item with exact match', () => {
+    expect(isNavItemActive({ href: '/about', type: 'link' }, '/about')).toBe(true)
+  })
+
+  it('returns true for HOME when pathname is empty string', () => {
+    expect(isNavItemActive({ href: '/', type: 'link' }, '')).toBe(true)
+  })
+
+  it('returns false for link-type item with no match', () => {
+    expect(isNavItemActive({ href: '/about', type: 'link' }, '/contact')).toBe(false)
+  })
+
+  it('returns true for dropdown when sub-item href matches', () => {
+    const dropdown = {
+      type: 'dropdown',
+      items: [
+        { href: '/essentials' },
+        { href: '/protest' },
+      ]
+    }
+    expect(isNavItemActive(dropdown, '/essentials')).toBe(true)
+  })
+
+  it('returns true for dropdown when pathname starts with sub-item href', () => {
+    const dropdown = {
+      type: 'dropdown',
+      items: [
+        { href: '/essentials' },
+      ]
+    }
+    expect(isNavItemActive(dropdown, '/essentials/something')).toBe(true)
+  })
+
+  it('returns false for dropdown when no sub-item matches', () => {
+    const dropdown = {
+      type: 'dropdown',
+      items: [
+        { href: '/essentials' },
+        { href: '/protest' },
+      ]
+    }
+    expect(isNavItemActive(dropdown, '/about')).toBe(false)
+  })
+
+  it('HOME does not match unrelated paths via / prefix', () => {
+    // The / href for HOME should only match "/" or "" exactly
+    expect(isNavItemActive(NAV_ITEMS.HOME, '/essentials')).toBe(false)
+  })
+})
+
+describe('findActiveSection', () => {
+  it('returns HOME for pathname /', () => {
+    const result = findActiveSection('/')
+    expect(result).toBeDefined()
+    expect(result.key).toBe('home')
+  })
+
+  it('returns SECURITY_CHECKLISTS for a checklist path', () => {
+    const result = findActiveSection('/essentials')
+    expect(result).toBeDefined()
+    expect(result.key).toBe('security-checklists')
+  })
+
+  it('returns undefined for unrecognized path', () => {
+    const result = findActiveSection('/nonexistent-page-xyz')
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('isSubItemActive', () => {
+  it('returns false for items with hash href', () => {
+    expect(isSubItemActive({ href: '#top' }, '/about')).toBe(false)
+  })
+
+  it('returns true for exact match', () => {
+    expect(isSubItemActive({ href: '/essentials' }, '/essentials')).toBe(true)
+  })
+
+  it('returns true when pathname starts with href', () => {
+    expect(isSubItemActive({ href: '/essentials' }, '/essentials/something')).toBe(true)
+  })
+
+  it('returns false when no match', () => {
+    expect(isSubItemActive({ href: '/essentials' }, '/protest')).toBe(false)
+  })
+
+  it('does not match / as prefix for all paths', () => {
+    // href '/' should only match exactly '/', not '/essentials'
+    expect(isSubItemActive({ href: '/' }, '/essentials')).toBe(false)
+  })
+})
+
+describe('Navigation config structure', () => {
+  it('mainNav has expected number of items', () => {
+    expect(navigationConfig.mainNav).toBeInstanceOf(Array)
+    expect(navigationConfig.mainNav.length).toBe(5)
+  })
+
+  it('all mainNav items have key property', () => {
+    for (const item of navigationConfig.mainNav) {
+      expect(item.key, `Nav item missing key`).toBeDefined()
+    }
+  })
+
+  it('SECURITY_CHECKLISTS items have required properties', () => {
+    for (const item of SECURITY_CHECKLISTS.items) {
+      expect(item.title, `Item ${item.key} missing title`).toBeDefined()
+      expect(item.href, `Item ${item.key} missing href`).toBeDefined()
+      expect(item.description, `Item ${item.key} missing description`).toBeDefined()
+      expect(item.icon, `Item ${item.key} missing icon`).toBeDefined()
+    }
+  })
+
+  it('footer has two sections', () => {
+    expect(footerConfig.sections).toHaveLength(2)
+  })
+
+  it('social links have required properties', () => {
+    for (const link of Object.values(SOCIAL_LINKS)) {
+      expect(link.href).toBeDefined()
+      expect(link.label).toBeDefined()
+      expect(link.icon).toBeDefined()
+      expect(link.ariaLabel).toBeDefined()
+    }
+  })
+
+  it('logo config is valid', () => {
+    expect(navigationConfig.logo.href).toBe('/')
+    expect(navigationConfig.logo.label).toBeDefined()
+    expect(navigationConfig.logo.image).toBeDefined()
+  })
+})

--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { ROUTES } from '../config/routes'
+
+// Recursively collect all route values from the ROUTES object
+function collectRoutes(obj, prefix = '') {
+  const routes = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      routes.push({ key: prefix ? `${prefix}.${key}` : key, value })
+    } else if (typeof value === 'object' && value !== null) {
+      routes.push(...collectRoutes(value, prefix ? `${prefix}.${key}` : key))
+    }
+  }
+  return routes
+}
+
+describe('Route configuration', () => {
+  const allRoutes = collectRoutes(ROUTES)
+
+  it('has routes defined', () => {
+    expect(allRoutes.length).toBeGreaterThan(0)
+  })
+
+  it('all routes are strings starting with /', () => {
+    for (const { key, value } of allRoutes) {
+      expect(value, `Route ${key} should start with /`).toMatch(/^\//)
+    }
+  })
+
+  it('has no duplicate route values', () => {
+    const values = allRoutes.map(r => r.value)
+    const duplicates = values.filter((v, i) => values.indexOf(v) !== i)
+    expect(duplicates, `Duplicate routes found: ${duplicates.join(', ')}`).toEqual([])
+  })
+
+  it('has expected top-level keys', () => {
+    expect(ROUTES.HOME).toBe('/')
+    expect(ROUTES.CHANGELOG).toBeDefined()
+    expect(ROUTES.NEWS).toBeDefined()
+    expect(ROUTES.CHECKLISTS).toBeDefined()
+    expect(ROUTES.ABOUT).toBeDefined()
+  })
+
+  it('has all expected checklist routes', () => {
+    expect(ROUTES.CHECKLISTS.LIST).toBeDefined()
+    expect(ROUTES.CHECKLISTS.ESSENTIALS).toBeDefined()
+    expect(ROUTES.CHECKLISTS.PROTEST).toBeDefined()
+    expect(ROUTES.CHECKLISTS.SIGNAL).toBeDefined()
+    expect(ROUTES.CHECKLISTS.DOXXING).toBeDefined()
+    expect(ROUTES.CHECKLISTS.TRAVEL).toBeDefined()
+    expect(ROUTES.CHECKLISTS.EMERGENCY).toBeDefined()
+    expect(ROUTES.CHECKLISTS.SECONDARY_PHONE).toBeDefined()
+    expect(ROUTES.CHECKLISTS.SPYWARE).toBeDefined()
+    expect(ROUTES.CHECKLISTS.RESEARCH).toBeDefined()
+    expect(ROUTES.CHECKLISTS.ORGANIZER).toBeDefined()
+    expect(ROUTES.CHECKLISTS.FEDERAL).toBeDefined()
+    expect(ROUTES.CHECKLISTS.ACTION).toBeDefined()
+  })
+
+  it('has about sub-routes', () => {
+    expect(ROUTES.ABOUT.INDEX).toBeDefined()
+    expect(ROUTES.ABOUT.CONTACT).toBeDefined()
+    expect(ROUTES.ABOUT.PRIVACY).toBeDefined()
+  })
+
+  it('PGP key file ends with .asc', () => {
+    expect(ROUTES.PGP_KEY_FILE).toMatch(/\.asc$/)
+  })
+})

--- a/components/forms/ContactForm.js
+++ b/components/forms/ContactForm.js
@@ -13,68 +13,12 @@ import {
 } from "@/components/ui/form";
 import { Badge } from "@/components/ui/badge";
 import { zodResolver } from "@hookform/resolvers/zod";
-import * as z from "zod";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 import { Alert } from '@/components/ui/alert';
-
-const MAX_CHARS = 5000;
-
-const RESPONSE_OPTIONS = [
-  { value: 'none', label: 'No response needed (your message remains anonymous)' },
-  { value: 'signal_username', label: 'Reply by Signal (username)', recommended: 'Most Secure' },
-  { value: 'signal_phone', label: 'Reply by Signal (phone number)' },
-  { value: 'email', label: 'Reply by Email' },
-];
-
-const formSchema = z.object({
-  message: z.string()
-    .min(1, "Message is required")
-    .max(MAX_CHARS, `Message must not exceed ${MAX_CHARS} characters`),
-  responseType: z.enum(RESPONSE_OPTIONS.map(opt => opt.value), {
-    required_error: "Please select how you'd like us to respond",
-  }),
-  email: z.string().email("Invalid email address").optional().or(z.literal('')),
-  signalUsername: z.string()
-    .transform(val => {
-      const cleaned = val.replace(/@/g, '').toLowerCase();
-      return cleaned ? `@${cleaned}` : cleaned;
-    })
-    .refine(val => {
-      if (!val) return true;
-      const username = val.slice(1);
-      return username.length >= 3 && username.length <= 32;
-    }, "Username must be between 3 and 32 characters")
-    .refine(val => {
-      if (!val) return true;
-      const username = val.slice(1);
-      return /^[a-z0-9_.]*$/.test(username);
-    }, "Username may only contain letters, numbers, underscores, and periods")
-    .refine(val => {
-      if (!val) return true;
-      const username = val.slice(1);
-      return /.*\.[0-9]{2,}$/.test(username);
-    }, "Username must end with a period followed by at least two numbers")
-    .optional()
-    .or(z.literal('')),
-  signalPhone: z.string().optional().or(z.literal('')),
-}).refine((data) => {
-  if (data.responseType === 'email') {
-    return !!data.email;
-  }
-  if (data.responseType === 'signal_username') {
-    return !!data.signalUsername;
-  }
-  if (data.responseType === 'signal_phone') {
-    return !!data.signalPhone;
-  }
-  return true;
-}, {
-  message: "Please provide the required contact information for your selected response method",
-  path: ['responseType'],
-});
+import { MAX_CHARS, RESPONSE_OPTIONS, formSchema } from './contactFormSchema';
 
 const ContactForm = ({ 
   successMessage = 'Message sent successfully!',

--- a/components/forms/contactFormSchema.js
+++ b/components/forms/contactFormSchema.js
@@ -1,0 +1,57 @@
+import * as z from "zod";
+
+export const MAX_CHARS = 5000;
+
+export const RESPONSE_OPTIONS = [
+  { value: 'none', label: 'No response needed (your message remains anonymous)' },
+  { value: 'signal_username', label: 'Reply by Signal (username)', recommended: 'Most Secure' },
+  { value: 'signal_phone', label: 'Reply by Signal (phone number)' },
+  { value: 'email', label: 'Reply by Email' },
+];
+
+export const formSchema = z.object({
+  message: z.string()
+    .min(1, "Message is required")
+    .max(MAX_CHARS, `Message must not exceed ${MAX_CHARS} characters`),
+  responseType: z.enum(RESPONSE_OPTIONS.map(opt => opt.value), {
+    required_error: "Please select how you'd like us to respond",
+  }),
+  email: z.string().email("Invalid email address").optional().or(z.literal('')),
+  signalUsername: z.string()
+    .transform(val => {
+      const cleaned = val.replace(/@/g, '').toLowerCase();
+      return cleaned ? `@${cleaned}` : cleaned;
+    })
+    .refine(val => {
+      if (!val) return true;
+      const username = val.slice(1);
+      return username.length >= 3 && username.length <= 32;
+    }, "Username must be between 3 and 32 characters")
+    .refine(val => {
+      if (!val) return true;
+      const username = val.slice(1);
+      return /^[a-z0-9_.]*$/.test(username);
+    }, "Username may only contain letters, numbers, underscores, and periods")
+    .refine(val => {
+      if (!val) return true;
+      const username = val.slice(1);
+      return /.*\.[0-9]{2,}$/.test(username);
+    }, "Username must end with a period followed by at least two numbers")
+    .optional()
+    .or(z.literal('')),
+  signalPhone: z.string().optional().or(z.literal('')),
+}).refine((data) => {
+  if (data.responseType === 'email') {
+    return !!data.email;
+  }
+  if (data.responseType === 'signal_username') {
+    return !!data.signalUsername;
+  }
+  if (data.responseType === 'signal_phone') {
+    return !!data.signalPhone;
+  }
+  return true;
+}, {
+  message: "Please provide the required contact information for your selected response method",
+  path: ['responseType'],
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postbuild": "if [ \"$VERCEL\" != \"1\" ]; then yarn storyblockexportimages; fi && next-sitemap && yarn rss && yarn index && if [ \"$BUILD_MODE\" = \"static\" ]; then cp public/.htaccess out/.htaccess; fi && if [ \"$VERCEL\" != \"1\" ]; then yarn fetch-news -q && if [ \"$BUILD_MODE\" = \"static\" ]; then mkdir -p out/files && cp -r public/files/news out/files/ 2>/dev/null || true; fi; fi && yarn buildbackup",
     "rss": "node scripts/generate-rss.js",
     "index": "NODE_ENV=${NODE_ENV} bash scripts/build-search-index.sh",
-    "buildstatic": "BUILD_MODE=static yarn build && yarn checkbuild",
+    "buildstatic": "BUILD_MODE=static yarn build && yarn checkbuild && yarn check-links",
     "checkbuild": "node scripts/check-build.mjs",
     "serve": "npx serve out",
     "buildbackup": "node scripts/build-backup.js",
@@ -30,7 +30,11 @@
     "api:delete": "yarn run pm2 delete ac-api",
     "api:logs": "yarn run pm2 logs ac-api",
     "fetch-news": "node scripts/fetch-news-images.js",
-    "metadata": "node scripts/metadata-cli.cjs"
+    "metadata": "node scripts/metadata-cli.cjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check-links": "node scripts/check-links.mjs",
+    "prepare": "sh scripts/install-hooks.sh"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.1",
@@ -105,6 +109,7 @@
     "storyblok-backup": "^0.5.0",
     "storyblok-js-client": "^6.10.3",
     "tailwindcss": "^3.4.16",
+    "vitest": "^4.0.18",
     "yarn": "^1.22.22"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,234 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const OUT_DIR = path.resolve(__dirname, '..', 'out');
+
+// Prefixes to skip -- these are managed by other tools or are external
+const SKIP_PREFIXES = ['/_next/', '/pagefind/'];
+
+// Patterns to extract href and src values from HTML
+const HREF_PATTERN = /href="([^"]*?)"/g;
+const SRC_PATTERN = /src="([^"]*?)"/g;
+const SRCSET_PATTERN = /srcset="([^"]*?)"/g;
+
+function getAllHtmlFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getAllHtmlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function shouldSkip(localPath) {
+  // Skip external URLs
+  if (localPath.startsWith('http://') || localPath.startsWith('https://') || localPath.startsWith('//')) {
+    return true;
+  }
+  // Skip non-path values
+  if (localPath.startsWith('mailto:') || localPath.startsWith('tel:') ||
+      localPath.startsWith('javascript:') || localPath.startsWith('data:') ||
+      localPath.startsWith('blob:')) {
+    return true;
+  }
+  // Skip fragment-only links
+  if (localPath.startsWith('#')) {
+    return true;
+  }
+  // Skip empty
+  if (!localPath || localPath.trim() === '') {
+    return true;
+  }
+  // Skip known build asset prefixes
+  for (const prefix of SKIP_PREFIXES) {
+    if (localPath.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function stripQueryAndFragment(urlPath) {
+  let cleaned = urlPath;
+  const hashIndex = cleaned.indexOf('#');
+  if (hashIndex !== -1) {
+    cleaned = cleaned.substring(0, hashIndex);
+  }
+  const queryIndex = cleaned.indexOf('?');
+  if (queryIndex !== -1) {
+    cleaned = cleaned.substring(0, queryIndex);
+  }
+  return cleaned;
+}
+
+function pathResolves(localPath) {
+  const cleaned = stripQueryAndFragment(localPath);
+  if (!cleaned || cleaned === '/') return true; // Root path always resolves
+
+  const fullPath = path.join(OUT_DIR, cleaned);
+
+  // Check if the exact path exists as a file
+  if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+    return true;
+  }
+
+  // Check if the exact path exists as a directory with index.html
+  if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
+    const indexPath = path.join(fullPath, 'index.html');
+    return fs.existsSync(indexPath);
+  }
+
+  // For paths without extension (e.g., /essentials), check path/index.html
+  const ext = path.extname(cleaned);
+  if (!ext) {
+    const indexPath = path.join(fullPath, 'index.html');
+    return fs.existsSync(indexPath);
+  }
+
+  return false;
+}
+
+function extractPaths(htmlContent) {
+  const paths = [];
+
+  // Extract href values
+  let match;
+  while ((match = HREF_PATTERN.exec(htmlContent)) !== null) {
+    paths.push({ path: match[1], type: 'link' });
+  }
+
+  // Extract src values
+  while ((match = SRC_PATTERN.exec(htmlContent)) !== null) {
+    paths.push({ path: match[1], type: 'resource' });
+  }
+
+  // Extract srcset values (may contain multiple URLs separated by commas)
+  while ((match = SRCSET_PATTERN.exec(htmlContent)) !== null) {
+    const srcsetValue = match[1];
+    // srcset contains entries like "/images/photo.jpg 1x, /images/photo@2x.jpg 2x"
+    for (const entry of srcsetValue.split(',')) {
+      const url = entry.trim().split(/\s+/)[0];
+      if (url) {
+        paths.push({ path: url, type: 'resource' });
+      }
+    }
+  }
+
+  return paths;
+}
+
+function main() {
+  if (!fs.existsSync(OUT_DIR)) {
+    console.error(chalk.red(`Output directory '${OUT_DIR}' does not exist. Run buildstatic first.`));
+    process.exit(0);
+  }
+
+  console.log(chalk.blue(`\nChecking internal links and images in ${chalk.bold(OUT_DIR)}...\n`));
+
+  const htmlFiles = getAllHtmlFiles(OUT_DIR);
+  console.log(chalk.gray(`  Found ${htmlFiles.length} HTML files to check`));
+
+  const brokenLinks = [];
+  const brokenResources = [];
+  const checkedPaths = new Map(); // cache: path -> resolves (boolean)
+
+  for (const file of htmlFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    const extracted = extractPaths(content);
+    const relativeFile = path.relative(OUT_DIR, file);
+
+    for (const { path: extractedPath, type } of extracted) {
+      if (shouldSkip(extractedPath)) continue;
+
+      const cleaned = stripQueryAndFragment(extractedPath);
+      if (!cleaned) continue;
+
+      // Use cache to avoid re-checking the same path
+      if (!checkedPaths.has(cleaned)) {
+        checkedPaths.set(cleaned, pathResolves(cleaned));
+      }
+
+      if (!checkedPaths.get(cleaned)) {
+        const entry = { sourceFile: relativeFile, path: extractedPath };
+        if (type === 'link') {
+          brokenLinks.push(entry);
+        } else {
+          brokenResources.push(entry);
+        }
+      }
+    }
+  }
+
+  // Deduplicate findings (same broken path reported from multiple files is fine, but same path+file is noise)
+  const dedup = (entries) => {
+    const seen = new Set();
+    return entries.filter(e => {
+      const key = `${e.sourceFile}::${e.path}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  };
+
+  const uniqueBrokenLinks = dedup(brokenLinks);
+  const uniqueBrokenResources = dedup(brokenResources);
+
+  // Report
+  if (uniqueBrokenLinks.length > 0) {
+    console.error(chalk.red.bold(`\n  Broken internal links (${uniqueBrokenLinks.length}):`));
+    // Group by broken path
+    const byPath = {};
+    for (const entry of uniqueBrokenLinks) {
+      if (!byPath[entry.path]) byPath[entry.path] = [];
+      byPath[entry.path].push(entry.sourceFile);
+    }
+    for (const [brokenPath, files] of Object.entries(byPath)) {
+      console.error(chalk.red(`    ${brokenPath}`));
+      for (const f of files.slice(0, 5)) {
+        console.error(chalk.gray(`      in ${f}`));
+      }
+      if (files.length > 5) {
+        console.error(chalk.gray(`      ... and ${files.length - 5} more files`));
+      }
+    }
+  }
+
+  if (uniqueBrokenResources.length > 0) {
+    console.error(chalk.red.bold(`\n  Broken local images/resources (${uniqueBrokenResources.length}):`));
+    const byPath = {};
+    for (const entry of uniqueBrokenResources) {
+      if (!byPath[entry.path]) byPath[entry.path] = [];
+      byPath[entry.path].push(entry.sourceFile);
+    }
+    for (const [brokenPath, files] of Object.entries(byPath)) {
+      console.error(chalk.red(`    ${brokenPath}`));
+      for (const f of files.slice(0, 5)) {
+        console.error(chalk.gray(`      in ${f}`));
+      }
+      if (files.length > 5) {
+        console.error(chalk.gray(`      ... and ${files.length - 5} more files`));
+      }
+    }
+  }
+
+  const totalBroken = uniqueBrokenLinks.length + uniqueBrokenResources.length;
+  const totalChecked = checkedPaths.size;
+
+  if (totalBroken === 0) {
+    console.log(chalk.green.bold(`\n  All ${totalChecked} local paths verified.\n`));
+    process.exit(0);
+  } else {
+    console.error(chalk.red.bold(`\n  ${totalBroken} broken paths found out of ${totalChecked} checked.\n`));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Install git hooks from tracked copies in scripts/
+# This runs automatically via the "prepare" script after yarn install
+
+HOOK_DIR="$(git rev-parse --git-dir 2>/dev/null)/hooks"
+
+if [ -z "$HOOK_DIR" ] || [ ! -d "$HOOK_DIR" ]; then
+  echo "Not a git repository or hooks directory not found. Skipping hook install."
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cp "$SCRIPT_DIR/pre-commit" "$HOOK_DIR/pre-commit"
+chmod +x "$HOOK_DIR/pre-commit"
+echo "Git pre-commit hook installed."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Running tests before commit..."
+yarn test
+
+if [ $? -ne 0 ]; then
+  echo "Tests failed. Commit aborted."
+  exit 1
+fi

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname),
+    },
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,136 @@
   dependencies:
     tslib "^2.4.0"
 
+"@esbuild/aix-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz#521cbd968dcf362094034947f76fa1b18d2d403c"
+  integrity sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==
+
+"@esbuild/android-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz#61ea550962d8aa12a9b33194394e007657a6df57"
+  integrity sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==
+
+"@esbuild/android-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.2.tgz#554887821e009dd6d853f972fde6c5143f1de142"
+  integrity sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==
+
+"@esbuild/android-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.2.tgz#a7ce9d0721825fc578f9292a76d9e53334480ba2"
+  integrity sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==
+
+"@esbuild/darwin-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz#2cb7659bd5d109803c593cfc414450d5430c8256"
+  integrity sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==
+
+"@esbuild/darwin-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz#e741fa6b1abb0cd0364126ba34ca17fd5e7bf509"
+  integrity sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==
+
+"@esbuild/freebsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz#2b64e7116865ca172d4ce034114c21f3c93e397c"
+  integrity sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==
+
+"@esbuild/freebsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz#e5252551e66f499e4934efb611812f3820e990bb"
+  integrity sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==
+
+"@esbuild/linux-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz#dc4acf235531cd6984f5d6c3b13dbfb7ddb303cb"
+  integrity sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==
+
+"@esbuild/linux-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz#56a900e39240d7d5d1d273bc053daa295c92e322"
+  integrity sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==
+
+"@esbuild/linux-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz#d4a36d473360f6870efcd19d52bbfff59a2ed1cc"
+  integrity sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==
+
+"@esbuild/linux-loong64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz#fcf0ab8c3eaaf45891d0195d4961cb18b579716a"
+  integrity sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==
+
+"@esbuild/linux-mips64el@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz#598b67d34048bb7ee1901cb12e2a0a434c381c10"
+  integrity sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==
+
+"@esbuild/linux-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz#3846c5df6b2016dab9bc95dde26c40f11e43b4c0"
+  integrity sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==
+
+"@esbuild/linux-riscv64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz#173d4475b37c8d2c3e1707e068c174bb3f53d07d"
+  integrity sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==
+
+"@esbuild/linux-s390x@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz#f7a4790105edcab8a5a31df26fbfac1aa3dacfab"
+  integrity sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==
+
+"@esbuild/linux-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz#2ecc1284b1904aeb41e54c9ddc7fcd349b18f650"
+  integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
+
+"@esbuild/netbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz#e2863c2cd1501845995cb11adf26f7fe4be527b0"
+  integrity sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==
+
+"@esbuild/netbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz#93f7609e2885d1c0b5a1417885fba8d1fcc41272"
+  integrity sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==
+
+"@esbuild/openbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz#a1985604a203cdc325fd47542e106fafd698f02e"
+  integrity sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==
+
+"@esbuild/openbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz#8209e46c42f1ffbe6e4ef77a32e1f47d404ad42a"
+  integrity sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==
+
+"@esbuild/openharmony-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz#8fade4441893d9cc44cbd7dcf3776f508ab6fb2f"
+  integrity sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==
+
+"@esbuild/sunos-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz#980d4b9703a16f0f07016632424fc6d9a789dfc2"
+  integrity sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==
+
+"@esbuild/win32-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz#1c09a3633c949ead3d808ba37276883e71f6111a"
+  integrity sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==
+
+"@esbuild/win32-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz#1b1e3a63ad4bef82200fef4e369e0fff7009eee5"
+  integrity sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==
+
+"@esbuild/win32-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
+  integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
+
 "@fastify/ajv-compiler@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@fastify/ajv-compiler/-/ajv-compiler-4.0.1.tgz#9567b4c09149a0f342e931c7196a8ed9dc292954"
@@ -455,6 +585,11 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@jridgewell/trace-mapping@^0.3.24":
   version "0.3.25"
@@ -1316,6 +1451,136 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
+"@rollup/rollup-android-arm-eabi@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz#add5e608d4e7be55bc3ca3d962490b8b1890e088"
+  integrity sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==
+
+"@rollup/rollup-android-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz#10bd0382b73592beee6e9800a69401a29da625c4"
+  integrity sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==
+
+"@rollup/rollup-darwin-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz#1e99ab04c0b8c619dd7bbde725ba2b87b55bfd81"
+  integrity sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==
+
+"@rollup/rollup-darwin-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz#69e741aeb2839d2e8f0da2ce7a33d8bd23632423"
+  integrity sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==
+
+"@rollup/rollup-freebsd-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz#3736c232a999c7bef7131355d83ebdf9651a0839"
+  integrity sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==
+
+"@rollup/rollup-freebsd-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz#227dcb8f466684070169942bd3998901c9bfc065"
+  integrity sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz#ba004b30df31b724f99ce66e7128248bea17cb0c"
+  integrity sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz#6929f3e07be6b6da5991f63c6b68b3e473d0a65a"
+  integrity sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==
+
+"@rollup/rollup-linux-arm64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz#06e89fd4a25d21fe5575d60b6f913c0e65297bfa"
+  integrity sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==
+
+"@rollup/rollup-linux-arm64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz#fddabf395b90990d5194038e6cd8c00156ed8ac0"
+  integrity sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==
+
+"@rollup/rollup-linux-loong64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz#04c10bb764bbf09a3c1bd90432e92f58d6603c36"
+  integrity sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==
+
+"@rollup/rollup-linux-loong64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz#f2450361790de80581d8687ea19142d8a4de5c0f"
+  integrity sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==
+
+"@rollup/rollup-linux-ppc64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz#0474f4667259e407eee1a6d38e29041b708f6a30"
+  integrity sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==
+
+"@rollup/rollup-linux-ppc64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz#9f32074819eeb1ddbe51f50ea9dcd61a6745ec33"
+  integrity sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==
+
+"@rollup/rollup-linux-riscv64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz#3fdb9d4b1e29fb6b6a6da9f15654d42eb77b99b2"
+  integrity sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==
+
+"@rollup/rollup-linux-riscv64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz#1de780d64e6be0e3e8762035c22e0d8ea68df8ed"
+  integrity sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==
+
+"@rollup/rollup-linux-s390x-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz#1da022ffd2d9e9f0fd8344ea49e113001fbcac64"
+  integrity sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==
+
+"@rollup/rollup-linux-x64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz#78c16eef9520bd10e1ea7a112593bb58e2842622"
+  integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
+
+"@rollup/rollup-linux-x64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz#a7598591b4d9af96cb3167b50a5bf1e02dfea06c"
+  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
+
+"@rollup/rollup-openbsd-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz#c51d48c07cd6c466560e5bed934aec688ce02614"
+  integrity sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==
+
+"@rollup/rollup-openharmony-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz#f09921d0b2a0b60afbf3586d2a7a7f208ba6df17"
+  integrity sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz#08d491717135376e4a99529821c94ecd433d5b36"
+  integrity sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz#b0c12aac1104a8b8f26a5e0098e5facbb3e3964a"
+  integrity sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==
+
+"@rollup/rollup-win32-x64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz#b9cccef26f5e6fdc013bf3c0911a3c77428509d0"
+  integrity sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==
+
+"@rollup/rollup-win32-x64-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz#a03348e7b559c792b6277cc58874b89ef46e1e72"
+  integrity sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==
+
+"@standard-schema/spec@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@storyblok/js@3.1.9":
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/@storyblok/js/-/js-3.1.9.tgz#01830a03814e053e65fccfa885f17fbcb16ab4f6"
@@ -1348,12 +1613,30 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/hast@^3.0.0":
   version "3.0.4"
@@ -1383,6 +1666,64 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.1.tgz#28fa185f67daaf7b7a1a8c1d445132c5d979f8bd"
   integrity sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==
+
+"@vitest/expect@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.0.18.tgz#361510d99fbf20eb814222e4afcb8539d79dc94d"
+  integrity sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.0.18"
+    "@vitest/utils" "4.0.18"
+    chai "^6.2.1"
+    tinyrainbow "^3.0.3"
+
+"@vitest/mocker@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.0.18.tgz#b9735da114ef65ea95652c5bdf13159c6fab4865"
+  integrity sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==
+  dependencies:
+    "@vitest/spy" "4.0.18"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.0.18.tgz#fbccd4d910774072ec15463553edb8ca5ce53218"
+  integrity sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==
+  dependencies:
+    tinyrainbow "^3.0.3"
+
+"@vitest/runner@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.0.18.tgz#c2c0a3ed226ec85e9312f9cc8c43c5b3a893a8b1"
+  integrity sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==
+  dependencies:
+    "@vitest/utils" "4.0.18"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.0.18.tgz#bcb40fd6d742679c2ac927ba295b66af1c6c34c5"
+  integrity sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==
+  dependencies:
+    "@vitest/pretty-format" "4.0.18"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.0.18.tgz#ba0f20503fb6d08baf3309d690b3efabdfa88762"
+  integrity sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==
+
+"@vitest/utils@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.0.18.tgz#9636b16d86a4152ec68a8d6859cff702896433d4"
+  integrity sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==
+  dependencies:
+    "@vitest/pretty-format" "4.0.18"
+    tinyrainbow "^3.0.3"
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -1496,6 +1837,11 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-types@^0.13.4:
   version "0.13.4"
@@ -1652,6 +1998,11 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+chai@^6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@3.0.0, chalk@~3.0.0:
   version "3.0.0"
@@ -2104,6 +2455,43 @@ entities@^6.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
   integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
+esbuild@^0.27.0:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.2.tgz#d83ed2154d5813a5367376bb2292a9296fc83717"
+  integrity sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.27.2"
+    "@esbuild/android-arm" "0.27.2"
+    "@esbuild/android-arm64" "0.27.2"
+    "@esbuild/android-x64" "0.27.2"
+    "@esbuild/darwin-arm64" "0.27.2"
+    "@esbuild/darwin-x64" "0.27.2"
+    "@esbuild/freebsd-arm64" "0.27.2"
+    "@esbuild/freebsd-x64" "0.27.2"
+    "@esbuild/linux-arm" "0.27.2"
+    "@esbuild/linux-arm64" "0.27.2"
+    "@esbuild/linux-ia32" "0.27.2"
+    "@esbuild/linux-loong64" "0.27.2"
+    "@esbuild/linux-mips64el" "0.27.2"
+    "@esbuild/linux-ppc64" "0.27.2"
+    "@esbuild/linux-riscv64" "0.27.2"
+    "@esbuild/linux-s390x" "0.27.2"
+    "@esbuild/linux-x64" "0.27.2"
+    "@esbuild/netbsd-arm64" "0.27.2"
+    "@esbuild/netbsd-x64" "0.27.2"
+    "@esbuild/openbsd-arm64" "0.27.2"
+    "@esbuild/openbsd-x64" "0.27.2"
+    "@esbuild/openharmony-arm64" "0.27.2"
+    "@esbuild/sunos-x64" "0.27.2"
+    "@esbuild/win32-arm64" "0.27.2"
+    "@esbuild/win32-ia32" "0.27.2"
+    "@esbuild/win32-x64" "0.27.2"
+
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -2139,6 +2527,13 @@ estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2189,6 +2584,11 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+expect-type@^1.2.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 extend@^3.0.0:
   version "3.0.2"
@@ -2374,6 +2774,11 @@ fdir@^6.2.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
   integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 feed@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/feed/-/feed-5.1.0.tgz#a64a7c4e127fbe01f10072e42f4964d8889fc6c0"
@@ -2463,7 +2868,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -2935,6 +3340,13 @@ lucide-react@^0.468.0:
   version "0.468.0"
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.468.0.tgz#830c1bfd905575ddd23b832baa420c87db166910"
   integrity sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -3442,6 +3854,11 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 nanoid@^3.3.6, nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
@@ -3574,6 +3991,11 @@ obliterator@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.4.tgz#fa650e019b2d075d745e44f1effeb13a2adbe816"
   integrity sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==
+
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
 
 on-exit-leak-free@^2.1.0:
   version "2.1.2"
@@ -3721,6 +4143,11 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 pdf-lib@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
@@ -3750,6 +4177,11 @@ picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pidusage@^2.0.21:
   version "2.0.21"
@@ -3970,6 +4402,15 @@ postcss@^8.4.47, postcss@^8.4.49:
   integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
   dependencies:
     nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.6:
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  dependencies:
+    nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -4324,6 +4765,40 @@ rfdc@^1.2.0, rfdc@^1.3.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
+rollup@^4.43.0:
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.57.1.tgz#947f70baca32db2b9c594267fe9150aa316e5a88"
+  integrity sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.57.1"
+    "@rollup/rollup-android-arm64" "4.57.1"
+    "@rollup/rollup-darwin-arm64" "4.57.1"
+    "@rollup/rollup-darwin-x64" "4.57.1"
+    "@rollup/rollup-freebsd-arm64" "4.57.1"
+    "@rollup/rollup-freebsd-x64" "4.57.1"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.57.1"
+    "@rollup/rollup-linux-arm-musleabihf" "4.57.1"
+    "@rollup/rollup-linux-arm64-gnu" "4.57.1"
+    "@rollup/rollup-linux-arm64-musl" "4.57.1"
+    "@rollup/rollup-linux-loong64-gnu" "4.57.1"
+    "@rollup/rollup-linux-loong64-musl" "4.57.1"
+    "@rollup/rollup-linux-ppc64-gnu" "4.57.1"
+    "@rollup/rollup-linux-ppc64-musl" "4.57.1"
+    "@rollup/rollup-linux-riscv64-gnu" "4.57.1"
+    "@rollup/rollup-linux-riscv64-musl" "4.57.1"
+    "@rollup/rollup-linux-s390x-gnu" "4.57.1"
+    "@rollup/rollup-linux-x64-gnu" "4.57.1"
+    "@rollup/rollup-linux-x64-musl" "4.57.1"
+    "@rollup/rollup-openbsd-x64" "4.57.1"
+    "@rollup/rollup-openharmony-arm64" "4.57.1"
+    "@rollup/rollup-win32-arm64-msvc" "4.57.1"
+    "@rollup/rollup-win32-ia32-msvc" "4.57.1"
+    "@rollup/rollup-win32-x64-gnu" "4.57.1"
+    "@rollup/rollup-win32-x64-msvc" "4.57.1"
+    fsevents "~2.3.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -4502,6 +4977,11 @@ shimmer@^1.2.0:
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -4585,6 +5065,16 @@ sprintf-js@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
   integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 storyblok-backup@^0.5.0:
   version "0.5.0"
@@ -4782,6 +5272,29 @@ thread-stream@^3.0.0:
   dependencies:
     real-require "^0.2.0"
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.2.tgz#bdd2737fe2ba40bd6f918ae26642f264b99ca251"
+  integrity sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==
+
+tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+
+tinyrainbow@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.0.3.tgz#984a5b1c1b25854a9b6bccbe77964d0593d1ea42"
+  integrity sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -4978,6 +5491,46 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
+"vite@^6.0.0 || ^7.0.0":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.1.tgz#7f6cfe8fb9074138605e822a75d9d30b814d6507"
+  integrity sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==
+  dependencies:
+    esbuild "^0.27.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.0.18:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.0.18.tgz#56f966353eca0b50f4df7540cd4350ca6d454a05"
+  integrity sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==
+  dependencies:
+    "@vitest/expect" "4.0.18"
+    "@vitest/mocker" "4.0.18"
+    "@vitest/pretty-format" "4.0.18"
+    "@vitest/runner" "4.0.18"
+    "@vitest/snapshot" "4.0.18"
+    "@vitest/spy" "4.0.18"
+    "@vitest/utils" "4.0.18"
+    es-module-lexer "^1.7.0"
+    expect-type "^1.2.2"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^3.10.0"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+    vite "^6.0.0 || ^7.0.0"
+    why-is-node-running "^2.3.0"
+
 vizion@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/vizion/-/vizion-2.2.1.tgz#04201ea45ffd145d5b5210e385a8f35170387fb2"
@@ -5045,6 +5598,14 @@ which@^4.0.0:
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
- Add Vitest with 101 tests across 7 test files covering routes, navigation helpers, utility functions, image loader, contact form schema validation, and link classification logic
- Extract contact form Zod schema to separate file for testability
- Add pre-commit hook that runs tests before every commit
- Add check-links.mjs that verifies all internal links and image paths resolve after static build (runs after URL rewriting)
- Update buildstatic pipeline to include link/image checking