### PR TITLE
Use archiveUrl with articleUrl as a fallback in RSS feed

### DIFF
--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -211,7 +211,7 @@ async function generateNewsRSS() {
       return {
         title: story.name || 'News Item',
         id: articleUrl,
-        link: articleUrl,
+        link: archiveUrl || articleUrl,
         description: enhancedDescription,
         content: enhancedDescription,
         author: [{


### PR DESCRIPTION
This looked mostly done? I just used the archiveUrl with a fallback. Looks like RSS is already including the real url in enhancedDescription as well as tags.