### PR TITLE
Remove errors from github actions log

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,11 @@ ErrorDocument 404 /404/index.html
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
+  # Capture REQUEST_URI into an env var so mod_headers can reference it (it can't
+  # access REQUEST_URI directly, only env vars). Used by the Onion-Location header
+  # below. The "-" target is a no-op pass-through; only the [E=...] flag has effect.
+  RewriteRule ^ - [E=ONION_URI:%{REQUEST_URI}]
+
   # Skip if the file/directory already exists at the bare path
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
@@ -40,5 +45,7 @@ ErrorDocument 404 /404/index.html
 
   # Advertise the Tor onion mirror to Tor Browser. OnionSpray serves the onion
   # from a separate host, so this header is only sent from the clearnet origin.
-  Header set Onion-Location "http://actchkqornmbfjlsiepfm57lqlqsbpflih6kzomq73gfsz4cesuhujad.onion%{REQUEST_URI}e"
+  # Reads ONION_URI which is set by the RewriteRule above (mod_headers can't read
+  # REQUEST_URI directly, hence the env-var dance).
+  Header set Onion-Location "http://actchkqornmbfjlsiepfm57lqlqsbpflih6kzomq73gfsz4cesuhujad.onion%{ONION_URI}e"
 </IfModule>

--- a/public/webhooks/deploy.php
+++ b/public/webhooks/deploy.php
@@ -533,11 +533,80 @@ if ($code !== 0) {
     ? 'disabled'
     : ($logged ? 'written' : 'WRITE FAILED - check PHP error log');
 
+  // Sanitize before embedding in the HTTP response (which surfaces in the GitHub
+  // Actions log and could be public). Collect every plausible username and home
+  // directory from PHP-side detection AND from the script's own output (in case
+  // PHP-FPM runs as a different user than the deploy command, or POSIX is disabled).
+  $combinedOutput = (is_string($stderr) ? $stderr : '') . "\n" . (is_string($stdout) ? $stdout : '');
+  $homesForSan = [];
+  $usersForSan = [];
+  if (isset($env['HOME']) && is_string($env['HOME']) && $env['HOME'] !== '') {
+    $homesForSan[] = $env['HOME'];
+  }
+  if (isset($env['USER']) && is_string($env['USER']) && $env['USER'] !== '') {
+    $usersForSan[] = $env['USER'];
+  }
+  if (function_exists('posix_geteuid') && function_exists('posix_getpwuid')) {
+    $info = @posix_getpwuid(posix_geteuid());
+    if (is_array($info)) {
+      if (isset($info['name']) && is_string($info['name'])) $usersForSan[] = $info['name'];
+      if (isset($info['dir']) && is_string($info['dir'])) $homesForSan[] = $info['dir'];
+    }
+  }
+  if (preg_match_all('/\b(?:user|whoami|USER|LOGNAME)=(\S+)/', $combinedOutput, $matches)) {
+    foreach ($matches[1] as $u) $usersForSan[] = $u;
+  }
+  if (preg_match_all('/\bHOME=(\S+)/', $combinedOutput, $matches)) {
+    foreach ($matches[1] as $h) {
+      // Skip already-sanitized values from prior log lines if any.
+      if ($h !== '~' && $h !== '') $homesForSan[] = $h;
+    }
+  }
+  // Longest paths first so /home/x/y is replaced before /home/x.
+  $homesForSan = array_values(array_unique($homesForSan));
+  $usersForSan = array_values(array_unique($usersForSan));
+  usort($homesForSan, fn($a, $b) => strlen($b) - strlen($a));
+
+  $sanitize = function (string $s) use ($homesForSan, $usersForSan, $secret, $deployEnv): string {
+    if ($secret !== '' && strlen($secret) >= 8) {
+      $s = str_replace($secret, '[REDACTED]', $s);
+    }
+    foreach ($deployEnv as $k => $v) {
+      if (!is_string($v) || $v === '') continue;
+      if (preg_match('/(SECRET|TOKEN|PASSWORD|PASS|KEY|CREDENTIAL|HMAC)/i', (string) $k)) {
+        $s = str_replace($v, '[REDACTED]', $s);
+      }
+    }
+    foreach ($usersForSan as $u) {
+      if ($u === '' || $u === 'root' || strlen($u) < 3) continue;
+      $s = preg_replace('/\b' . preg_quote($u, '/') . '\b/', '[user]', $s) ?? $s;
+    }
+    foreach ($homesForSan as $h) {
+      if ($h === '' || $h === '/' || $h === DIRECTORY_SEPARATOR) continue;
+      $s = str_replace(rtrim($h, DIRECTORY_SEPARATOR), '~', $s);
+    }
+    return $s;
+  };
+
+  $tailBytes = 50000;
+  $stderrTail = is_string($stderr) ? $sanitize((string) substr($stderr, -$tailBytes)) : '';
+  $stdoutTail = is_string($stdout) ? $sanitize((string) substr($stdout, -$tailBytes)) : '';
+  $stderrTail = $stderrTail === '' ? '(empty)' : $stderrTail;
+  $stdoutTail = $stdoutTail === '' ? '(empty)' : $stdoutTail;
+
   $body = <<<TXT
 Deploy failed (exit code {$code}).
 
 GitHub delivery: {$deliveryLine}
 Server log: {$logStatus}
+
+Output below: \$HOME paths collapsed to ~, secrets redacted.
+
+--- script stderr (last {$tailBytes} bytes) ---
+{$stderrTail}
+
+--- script stdout (last {$tailBytes} bytes) ---
+{$stdoutTail}
 TXT;
   exit($body);
 }

--- a/public/webhooks/deploy.php
+++ b/public/webhooks/deploy.php
@@ -494,17 +494,32 @@ if ($logRaw === false) {
   exit('Configuration error');
 }
 
-if ($logFile !== null) {
-  $line = sprintf(
-    "[%s] exit=%d delivery=%s\n--- stdout ---\n%s\n--- stderr ---\n%s\n",
-    gmdate('c'),
-    $code,
-    $_SERVER['HTTP_X_GITHUB_DELIVERY'] ?? '',
-    is_string($stdout) ? $stdout : '',
-    is_string($stderr) ? $stderr : ''
-  );
-  if (file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX) === false) {
-    error_log('deploy-webhook: could not write log file: ' . $logFile);
+$line = sprintf(
+  "[%s] exit=%d delivery=%s\n--- stdout ---\n%s\n--- stderr ---\n%s\n",
+  gmdate('c'),
+  $code,
+  $_SERVER['HTTP_X_GITHUB_DELIVERY'] ?? '',
+  is_string($stdout) ? $stdout : '',
+  is_string($stderr) ? $stderr : ''
+);
+
+// Try the configured log path first, then a known-writable repo-root fallback so we
+// never silently lose the deploy output. If user explicitly set log_file => false
+// ($logFile === null), respect that and skip logging entirely.
+$logFallback = $repoRoot . DIRECTORY_SEPARATOR . '.deploy-webhook.log';
+$logged = false;
+$loggingDisabled = ($logFile === null);
+if (!$loggingDisabled) {
+  if (@file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX) === false) {
+    error_log('deploy-webhook: could not write log_file (configured); falling back');
+    if ($logFile !== $logFallback
+        && @file_put_contents($logFallback, $line, FILE_APPEND | LOCK_EX) !== false) {
+      $logged = true;
+    } else {
+      error_log('deploy-webhook: could not write fallback log at repo root either');
+    }
+  } else {
+    $logged = true;
   }
 }
 
@@ -514,28 +529,15 @@ if ($code !== 0) {
   header('Content-Type: text/plain; charset=UTF-8');
   $delivery = $_SERVER['HTTP_X_GITHUB_DELIVERY'] ?? '';
   $deliveryLine = is_string($delivery) && $delivery !== '' ? $delivery : '(unknown)';
-
-  // Surface the script's actual output to the caller (GitHub Actions log) so failures
-  // are diagnosable without server access. Endpoint requires HMAC; only authorized
-  // callers see this. Tail to keep the response small.
-  $tailBytes = 8000;
-  $stderrTail = is_string($stderr) ? (string) substr($stderr, -$tailBytes) : '';
-  $stdoutTail = is_string($stdout) ? (string) substr($stdout, -$tailBytes) : '';
-  $stderrTail = $stderrTail === '' ? '(empty)' : $stderrTail;
-  $stdoutTail = $stdoutTail === '' ? '(empty)' : $stdoutTail;
-  $logFileLine = $logFile !== null ? $logFile : '(disabled)';
+  $logStatus = $loggingDisabled
+    ? 'disabled'
+    : ($logged ? 'written' : 'WRITE FAILED - check PHP error log');
 
   $body = <<<TXT
 Deploy failed (exit code {$code}).
 
 GitHub delivery: {$deliveryLine}
-Full log on server: {$logFileLine}
-
---- script stderr (last {$tailBytes} bytes) ---
-{$stderrTail}
-
---- script stdout (last {$tailBytes} bytes) ---
-{$stdoutTail}
+Server log: {$logStatus}
 TXT;
   exit($body);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook logging reliability with automatic fallback if the primary log write fails; responses indicate whether logging succeeded.
  * Deploy failure responses no longer expose full server log paths and now report only exit code, delivery ID, and logging status.

* **Security / Privacy**
  * Script output embedded in responses is now sanitized: secrets and user/home path patterns are redacted/collapsed before inclusion.

* **Headers**
  * Onion-Location header generation adjusted to use a captured request URI for consistent, correct values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->