### PR TITLE
next.config: pin outputFileTracingRoot to silence multi-lockfile detection

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,15 @@ const baseConfig = {
       permanent,
     }));
   },
+  // Pin the workspace root so Next.js doesn't auto-detect a stray
+  // package-lock.json or yarn.lock in a parent directory and start resolving
+  // node_modules from there. The deploy server had an unrelated
+  // package-lock.json one level above the project; Next.js picked that as
+  // the workspace root and resolved deps from a parallel node_modules tree
+  // with stale @radix-ui/react-slot, breaking the build with "createSlot is
+  // not exported from @radix-ui/react-slot". Setting this anchors module
+  // resolution to THIS project's directory regardless of what's around it.
+  outputFileTracingRoot: __dirname,
   // Smaller server/client bundles and faster compiles for barrel-import icon packages.
   experimental: {
     optimizePackageImports: ['lucide-react', 'react-icons'],


### PR DESCRIPTION
Deploy was failing with "'createSlot' is not exported from
@radix-ui/react-slot" — a webpack import-resolution error that didn't
reproduce locally. The smoking gun was earlier in the build log:

  We detected multiple lockfiles and selected the directory of
  ~/include/package-lock.json as the root directory.
  Detected additional lockfiles:
    * ~/include/ActivistChecklist.org/yarn.lock

The deploy server has an unrelated package-lock.json one level above
the project (left over from another tool). Next.js auto-detected it
as the workspace root and started resolving node_modules from
~/include/node_modules — a parallel npm-managed tree with an older
@radix-ui/react-slot that doesn't export createSlot. cmdk's bundled
react-primitive imports createSlot, so the build broke.

Pinning outputFileTracingRoot to __dirname tells Next "this directory
IS the workspace root, don't look upward." Module resolution stays in
the project's own node_modules tree regardless of what's in parent
directories.

The stray ~/include/package-lock.json should also be deleted on the
server, but this config change is the durable fix — it'll keep the
build green even if the file shows up again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build configuration to correctly resolve dependencies from the project directory, preventing interference from files in parent workspace directories. This improves build reliability in monorepo environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->