### PR TITLE
Add inline newsletter CTA to guides and pages

### DIFF
--- a/__tests__/inline-cta-split.test.js
+++ b/__tests__/inline-cta-split.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { splitGuideBodyForCta, splitPageContentForCta } from '../lib/inline-cta-split';
+
+describe('splitGuideBodyForCta', () => {
+  it('splits after the first Section that contains a ChecklistItem', () => {
+    const content = [
+      '<Section title="Get started" slug="get-started">',
+      '  <ChecklistItem slug="signal" />',
+      '</Section>',
+      '',
+      '<Section title="Next" slug="next">',
+      '  <ChecklistItem slug="updates" />',
+      '</Section>',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta(content);
+
+    expect(didSplit).toBe(true);
+    expect(beforeCta).toContain('Get started');
+    expect(beforeCta).toContain('signal');
+    expect(beforeCta.trim().endsWith('</Section>')).toBe(true);
+    expect(afterCta).toContain('Next');
+    expect(afterCta).not.toContain('Get started');
+  });
+
+  it('skips intro-only sections without checklist items', () => {
+    const content = [
+      '<Section title="Intro" slug="intro">',
+      '  Some plain text explaining the guide.',
+      '</Section>',
+      '',
+      '<Section title="Steps" slug="steps">',
+      '  <ChecklistItemGroup>',
+      '    <ChecklistItem slug="foo" />',
+      '  </ChecklistItemGroup>',
+      '</Section>',
+      '',
+      '<Section title="More" slug="more">',
+      '  <ChecklistItem slug="bar" />',
+      '</Section>',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta(content);
+
+    expect(didSplit).toBe(true);
+    expect(beforeCta).toContain('Intro');
+    expect(beforeCta).toContain('Steps');
+    expect(beforeCta).toContain('foo');
+    expect(beforeCta).not.toContain('More');
+    expect(afterCta).toContain('More');
+    expect(afterCta).toContain('bar');
+  });
+
+  it('returns didSplit=false when no section has checklist items', () => {
+    const content = [
+      '<Section title="A" slug="a">Just text.</Section>',
+      '<Section title="B" slug="b">More text.</Section>',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta(content);
+
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe(content);
+    expect(afterCta).toBe('');
+  });
+
+  it('returns didSplit=false when content is empty', () => {
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta('');
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe('');
+    expect(afterCta).toBe('');
+  });
+
+  it('skips auto-split when content contains a manual <InlineCta />', () => {
+    const content = [
+      '<Section title="Get started" slug="get-started">',
+      '  <ChecklistItem slug="signal" />',
+      '</Section>',
+      '',
+      '<InlineCta />',
+      '',
+      '<Section title="Next" slug="next">',
+      '  <ChecklistItem slug="updates" />',
+      '</Section>',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta(content);
+
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe(content);
+    expect(afterCta).toBe('');
+  });
+
+  it('handles a single section with checklist items by leaving afterCta empty', () => {
+    const content = [
+      '<Section title="Only" slug="only">',
+      '  <ChecklistItem slug="alpha" />',
+      '</Section>',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitGuideBodyForCta(content);
+
+    expect(didSplit).toBe(true);
+    expect(beforeCta).toContain('alpha');
+    expect(afterCta).toBe('');
+  });
+});
+
+describe('splitPageContentForCta', () => {
+  it('splits before the second H2', () => {
+    const content = [
+      'Intro paragraph.',
+      '',
+      '## First heading',
+      '',
+      'Some body content.',
+      '',
+      '## Second heading',
+      '',
+      'More content.',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(true);
+    expect(beforeCta).toContain('First heading');
+    expect(beforeCta).toContain('Some body content');
+    expect(beforeCta).not.toContain('Second heading');
+    expect(afterCta).toMatch(/^##\s+Second heading/);
+  });
+
+  it('returns didSplit=false when there is only one H2', () => {
+    const content = ['Intro.', '', '## Only heading', '', 'Body.'].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe(content);
+    expect(afterCta).toBe('');
+  });
+
+  it('returns didSplit=false when there are no H2s', () => {
+    const content = 'Just some paragraphs, no headings here.';
+
+    const { beforeCta, afterCta, didSplit } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe(content);
+    expect(afterCta).toBe('');
+  });
+
+  it('skips auto-split when content contains a manual <InlineCta />', () => {
+    const content = [
+      '## One',
+      'Body.',
+      '<InlineCta />',
+      '## Two',
+      'More.',
+    ].join('\n');
+
+    const { didSplit, beforeCta } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(false);
+    expect(beforeCta).toBe(content);
+  });
+
+  it('ignores `## ` inside fenced code blocks', () => {
+    const content = [
+      '## Real heading',
+      '',
+      '```',
+      '## not a heading',
+      '## also not',
+      '```',
+      '',
+      'Body.',
+    ].join('\n');
+
+    const { didSplit } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(false);
+  });
+
+  it('recognizes raw <h2> tags', () => {
+    const content = [
+      '<h2>First</h2>',
+      'Body.',
+      '<h2>Second</h2>',
+      'More.',
+    ].join('\n');
+
+    const { beforeCta, afterCta, didSplit } = splitPageContentForCta(content);
+
+    expect(didSplit).toBe(true);
+    expect(beforeCta).toContain('First');
+    expect(beforeCta).not.toContain('Second');
+    expect(afterCta).toContain('Second');
+  });
+
+  it('does not treat ### as ##', () => {
+    const content = ['## H2', 'Body.', '### H3', 'More.'].join('\n');
+    const { didSplit } = splitPageContentForCta(content);
+    expect(didSplit).toBe(false);
+  });
+});

--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -10,6 +10,10 @@ import Guide from '@/components/guides/Guide';
 import ContentPage from '@/components/pages/Page';
 import { mdxOptions } from '@/lib/mdx-options';
 import {
+  splitGuideBodyForCta,
+  splitPageContentForCta,
+} from '@/lib/inline-cta-split';
+import {
   getRouteTranslationStatus,
   shouldShowTranslationUnreviewedNotice,
 } from '@/lib/crowdin-translation-status';
@@ -179,7 +183,16 @@ export default async function SlugPage({ params }) {
       firstSectionIndex === -1 ? '' : content.slice(firstSectionIndex).trim();
 
     const serializedIntro = introContent ? await serialize(introContent, mdxOptions) : null;
-    const serializedBody = sectionContent ? await serialize(sectionContent, mdxOptions) : null;
+
+    // Split body around the auto-inserted inline CTA. Suppressed when the
+    // guide frontmatter opts out or the body already contains a manual <InlineCta />.
+    const hideInlineCta = frontmatter?.hideInlineCta === true;
+    const { beforeCta, afterCta, didSplit } = hideInlineCta
+      ? { beforeCta: sectionContent, afterCta: '', didSplit: false }
+      : splitGuideBodyForCta(sectionContent);
+    const serializedBodyBeforeCta = beforeCta ? await serialize(beforeCta, mdxOptions) : null;
+    const serializedBodyAfterCta = afterCta ? await serialize(afterCta, mdxOptions) : null;
+    const showInlineCta = didSplit && !hideInlineCta;
 
     // Resolve all referenced checklist items
     const itemSlugs = extractChecklistItems(content);
@@ -225,7 +238,9 @@ export default async function SlugPage({ params }) {
         <Guide
           frontmatter={guideFm}
           serializedIntro={serializedIntro}
-          serializedBody={serializedBody}
+          serializedBodyBeforeCta={serializedBodyBeforeCta}
+          serializedBodyAfterCta={serializedBodyAfterCta}
+          showInlineCta={showInlineCta}
           checklistItems={checklistItems}
           slug={slug}
           locale={locale}
@@ -240,7 +255,13 @@ export default async function SlugPage({ params }) {
   if (page) {
     const { frontmatter, content, isFallback } = page;
 
-    const serializedBody = await serialize(content, mdxOptions);
+    const hidePageInlineCta = frontmatter?.hideInlineCta === true;
+    const { beforeCta: pageBefore, afterCta: pageAfter, didSplit: pageDidSplit } = hidePageInlineCta
+      ? { beforeCta: content, afterCta: '', didSplit: false }
+      : splitPageContentForCta(content);
+    const serializedBodyBeforeCta = pageBefore ? await serialize(pageBefore, mdxOptions) : null;
+    const serializedBodyAfterCta = pageAfter ? await serialize(pageAfter, mdxOptions) : null;
+    const showInlineCta = pageDidSplit && !hidePageInlineCta;
 
     // Generate OG image at build time
     try {
@@ -263,7 +284,9 @@ export default async function SlugPage({ params }) {
       >
         <ContentPage
           frontmatter={fm}
-          serializedBody={serializedBody}
+          serializedBodyBeforeCta={serializedBodyBeforeCta}
+          serializedBodyAfterCta={serializedBodyAfterCta}
+          showInlineCta={showInlineCta}
           locale={locale}
           notices={pageNotices}
         />

--- a/components/InlineCta.js
+++ b/components/InlineCta.js
@@ -6,6 +6,7 @@ import { Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Alert } from '@/components/ui/alert';
+import Link from '@/components/Link';
 import { useNewsletterSubscribe } from '@/components/NewsletterSubscribe';
 
 /**
@@ -21,7 +22,7 @@ export default function InlineCta() {
   const t = useTranslations();
   const [email, setEmail] = useState('');
   const [showForm, setShowForm] = useState(true);
-  const { status, error, subscribe } = useNewsletterSubscribe();
+  const { status, error, subscribe } = useNewsletterSubscribe('inline');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -37,9 +38,9 @@ export default function InlineCta() {
       data-inline-cta
       className="not-prose my-8 rounded-lg bg-foreground text-background dark:bg-primary/15 dark:text-foreground px-5 py-5 sm:px-6 sm:py-5 print:hidden"
     >
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
         <div className="flex-1 min-w-0">
-          <p className="font-heading text-lg font-semibold leading-tight mb-1">
+          <p className="font-heading text-lg font-semibold leading-tight mb-1 text-balance">
             {t('inlineCta.heading')}
           </p>
           <p className="text-sm leading-snug opacity-90 dark:opacity-100 dark:text-muted-foreground">
@@ -47,7 +48,7 @@ export default function InlineCta() {
           </p>
         </div>
 
-        <div className="sm:max-w-xs sm:w-full sm:shrink-0">
+        <div className="lg:max-w-xs lg:w-full lg:shrink-0">
           {status === 'error' && (
             <Alert variant="error" className="mb-2 text-sm newsletter-alert">
               {error}
@@ -59,26 +60,33 @@ export default function InlineCta() {
             </Alert>
           )}
           {showForm && (
-            <form onSubmit={handleSubmit} className="flex gap-2">
-              <Input
-                type="email"
-                name="email"
-                aria-label={t('inlineCta.emailAriaLabel')}
-                placeholder={t('newsletter.placeholders.emailShort')}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                disabled={status === 'loading'}
-                className="flex-1 text-foreground"
-              />
-              <Button type="submit" disabled={status === 'loading'} variant="default">
-                {status === 'loading' ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  t('inlineCta.buttonText')
-                )}
-              </Button>
-            </form>
+            <>
+              <form onSubmit={handleSubmit} className="flex gap-2">
+                <Input
+                  type="email"
+                  name="email"
+                  aria-label={t('inlineCta.emailAriaLabel')}
+                  placeholder={t('newsletter.placeholders.emailShort')}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  disabled={status === 'loading'}
+                  className="flex-1 text-foreground"
+                />
+                <Button type="submit" disabled={status === 'loading'} variant="default">
+                  {status === 'loading' ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    t('inlineCta.buttonText')
+                  )}
+                </Button>
+              </form>
+              <p className="mt-1.5 text-xs text-right opacity-60 dark:opacity-100 dark:text-muted-foreground">
+                <Link href="/privacy/" className="hover:underline">
+                  {t('inlineCta.privacyLink')}
+                </Link>
+              </p>
+            </>
           )}
         </div>
       </div>

--- a/components/InlineCta.js
+++ b/components/InlineCta.js
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Alert } from '@/components/ui/alert';
+import { useNewsletterSubscribe } from '@/components/NewsletterSubscribe';
+
+/**
+ * Inline newsletter CTA rendered between sections of a guide or page.
+ * Auto-inserted by the page route (see lib/inline-cta-split.js) or placed
+ * manually in MDX via <InlineCta />.
+ *
+ * Visual intent: Substack-style aside — dark surface in light mode so it
+ * reads as a distinct break from surrounding checklist cards, primary-tinted
+ * surface in dark mode. Compact (not banner-tall).
+ */
+export default function InlineCta() {
+  const t = useTranslations();
+  const [email, setEmail] = useState('');
+  const [showForm, setShowForm] = useState(true);
+  const { status, error, subscribe } = useNewsletterSubscribe();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const success = await subscribe(email);
+    if (success) {
+      setEmail('');
+      setShowForm(false);
+    }
+  };
+
+  return (
+    <aside
+      data-inline-cta
+      className="not-prose my-8 rounded-lg bg-foreground text-background dark:bg-primary/15 dark:text-foreground px-5 py-5 sm:px-6 sm:py-5 print:hidden"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+        <div className="flex-1 min-w-0">
+          <p className="font-heading text-lg font-semibold leading-tight mb-1">
+            {t('inlineCta.heading')}
+          </p>
+          <p className="text-sm leading-snug opacity-90 dark:opacity-100 dark:text-muted-foreground">
+            {t('inlineCta.description')}
+          </p>
+        </div>
+
+        <div className="sm:max-w-xs sm:w-full sm:shrink-0">
+          {status === 'error' && (
+            <Alert variant="error" className="mb-2 text-sm newsletter-alert">
+              {error}
+            </Alert>
+          )}
+          {status === 'success' && !showForm && (
+            <Alert variant="success" className="text-sm newsletter-alert">
+              {t('newsletter.successShort')}
+            </Alert>
+          )}
+          {showForm && (
+            <form onSubmit={handleSubmit} className="flex gap-2">
+              <Input
+                type="email"
+                name="email"
+                aria-label={t('inlineCta.emailAriaLabel')}
+                placeholder={t('newsletter.placeholders.emailShort')}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={status === 'loading'}
+                className="flex-1 text-foreground"
+              />
+              <Button type="submit" disabled={status === 'loading'} variant="default">
+                {status === 'loading' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  t('inlineCta.buttonText')
+                )}
+              </Button>
+            </form>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/components/NewsletterSubscribe.js
+++ b/components/NewsletterSubscribe.js
@@ -7,7 +7,7 @@ import { Loader2 } from 'lucide-react';
 import { Alert } from '@/components/ui/alert';
 import { useTranslations } from 'next-intl';
 
-function useNewsletterSubscribe() {
+export function useNewsletterSubscribe() {
   const [status, setStatus] = useState('idle');
   const [error, setError] = useState('');
 

--- a/components/NewsletterSubscribe.js
+++ b/components/NewsletterSubscribe.js
@@ -6,10 +6,17 @@ import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import { Alert } from '@/components/ui/alert';
 import { useTranslations } from 'next-intl';
+import { useAnalytics } from '@/hooks/use-analytics';
 
-export function useNewsletterSubscribe() {
+/**
+ * @param {string} context - where the subscribe form is rendered (e.g. 'footer',
+ *   'inline'). Sent to Umami as event data so we can tell which placements
+ *   convert. NEVER pass the email address — analytics stays anonymous.
+ */
+export function useNewsletterSubscribe(context = 'unknown') {
   const [status, setStatus] = useState('idle');
   const [error, setError] = useState('');
+  const { trackEvent } = useAnalytics();
 
   const subscribe = async (email) => {
     setStatus('loading');
@@ -28,6 +35,10 @@ export function useNewsletterSubscribe() {
 
       if (result.success) {
         setStatus('success');
+        trackEvent({
+          name: 'newsletter_subscribed',
+          data: { context },
+        });
         return true;
       } else {
         setStatus('error');
@@ -48,11 +59,11 @@ export function useNewsletterSubscribe() {
   };
 }
 
-export function NewsletterSubscribeForm({ onSuccess }) {
+export function NewsletterSubscribeForm({ onSuccess, context = 'form' }) {
   const t = useTranslations();
   const [email, setEmail] = useState('');
   const [showForm, setShowForm] = useState(true);
-  const { status, error, subscribe } = useNewsletterSubscribe();
+  const { status, error, subscribe } = useNewsletterSubscribe(context);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -114,11 +125,11 @@ export function NewsletterSubscribeForm({ onSuccess }) {
   );
 }
 
-export function CompactNewsletterSubscribe() {
+export function CompactNewsletterSubscribe({ context = 'footer' } = {}) {
   const t = useTranslations();
   const [email, setEmail] = useState('');
   const [showForm, setShowForm] = useState(true);
-  const { status, error, subscribe } = useNewsletterSubscribe();
+  const { status, error, subscribe } = useNewsletterSubscribe(context);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/components/guides/Guide.js
+++ b/components/guides/Guide.js
@@ -8,6 +8,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { mdxComponents } from '@/lib/mdx-components';
 import { ChecklistItemsContext } from '@/contexts/ChecklistItemsContext';
 import { FeedbackCTA } from '@/components/guides/FeedbackCTA';
+import InlineCta from '@/components/InlineCta';
 import { useLayout } from '@/contexts/LayoutContext';
 import { getGuideIcon } from '@/config/icons';
 import RelatedGuides from '@/components/RelatedGuides';
@@ -33,7 +34,17 @@ function parseRelatedGuides(value) {
  *   - checklistItems: { [slug]: { frontmatter, serializedBody } } map for ChecklistItemsContext
  *   - locale: BCP 47 locale string for date formatting (provided by parent Server Component)
  */
-export default function Guide({ frontmatter, serializedIntro, serializedBody, checklistItems = {}, slug, locale, notices = [] }) {
+export default function Guide({
+  frontmatter,
+  serializedIntro,
+  serializedBodyBeforeCta,
+  serializedBodyAfterCta,
+  showInlineCta = false,
+  checklistItems = {},
+  slug,
+  locale,
+  notices = [],
+}) {
   const t = useTranslations();
   // Prefer locale from NextIntlClientProvider (set by the locale layout), fall back to prop
   const intlLocale = useLocale() || locale || 'en';
@@ -102,7 +113,13 @@ export default function Guide({ frontmatter, serializedIntro, serializedBody, ch
               <MDXRemote {...serializedIntro} components={mdxComponents} />
             </div>
           )}
-          {serializedBody && <MDXRemote {...serializedBody} components={mdxComponents} />}
+          {serializedBodyBeforeCta && (
+            <MDXRemote {...serializedBodyBeforeCta} components={mdxComponents} />
+          )}
+          {showInlineCta && <InlineCta />}
+          {serializedBodyAfterCta && (
+            <MDXRemote {...serializedBodyAfterCta} components={mdxComponents} />
+          )}
           {relatedGuideSlugs.length > 0 && (
             <RelatedGuides isBlock guideSlugs={relatedGuideSlugs} />
           )}

--- a/components/pages/Page.js
+++ b/components/pages/Page.js
@@ -7,6 +7,7 @@ import { mdxComponents } from '@/lib/mdx-components';
 import { useLayout } from '@/contexts/LayoutContext';
 import { MetaBar, getDateMetaItem } from '@/components/ui/meta-bar';
 import RelatedGuides from '@/components/RelatedGuides';
+import InlineCta from '@/components/InlineCta';
 import { LOCALES } from "@/lib/i18n-config";
 import PageNotices from '@/components/layout/PageNotices';
 
@@ -27,7 +28,14 @@ function parseRelatedGuides(value) {
  *   - serializedBody: next-mdx-remote compiled MDX
  *   - locale: BCP 47 locale string for date formatting (provided by parent Server Component)
  */
-export default function Page({ frontmatter, serializedBody, locale, notices = [] }) {
+export default function Page({
+  frontmatter,
+  serializedBodyBeforeCta,
+  serializedBodyAfterCta,
+  showInlineCta = false,
+  locale,
+  notices = [],
+}) {
   const t = useTranslations();
   const intlLocale = useLocale() || locale || 'en';
   const dateLocale = LOCALES[intlLocale]?.intlLocale || 'en-US';
@@ -48,7 +56,13 @@ export default function Page({ frontmatter, serializedBody, locale, notices = []
       <PageNotices initialNotices={notices} />
       {metaBarItems.length > 0 && <MetaBar items={metaBarItems} />}
       <div className="prose prose-slate max-w-none">
-        <MDXRemote {...serializedBody} components={mdxComponents} />
+        {serializedBodyBeforeCta && (
+          <MDXRemote {...serializedBodyBeforeCta} components={mdxComponents} />
+        )}
+        {showInlineCta && <InlineCta />}
+        {serializedBodyAfterCta && (
+          <MDXRemote {...serializedBodyAfterCta} components={mdxComponents} />
+        )}
       </div>
       {relatedGuideSlugs.length > 0 && (
         <RelatedGuides isBlock guideSlugs={relatedGuideSlugs} />

--- a/content/en/pages/privacy.mdx
+++ b/content/en/pages/privacy.mdx
@@ -76,7 +76,9 @@ If you subscribe to our newsletter, we save your email address in a database sto
 
 We send emails directly from our server, rather than using newsletter tools, so your IP address and activity are protected. This tool does track link clicks, but it doesn’t attribute them to individuals, so your privacy is protected (and we can still see what’s working in our emails). It doesn’t keep logs or track IP addresses if you visit the unsubscribe page. (Our [newsletter system](https://github.com/knadh/listmonk) is open source if you want to review it.)
 
-If you want an extra layer of privacy, you can subscribe using an email anonymization service like Proton Mail’s hide-my-email aliases (10 aliases on the free plan, unlimited on the paid plan) or [addy.io](http://addy.io) (which offers unlimited aliases).
+We protect access to this service with [Cloudflare](https://www.cloudflare.com/privacypolicy/) so that it's much harder for someone to hack into our newsletter software and steal everyone's email addresses. That means Cloudflare does have the ability to track IP addresses. But their privacy policy says they only retain this information for 4 hours in most cases.
+
+If you want an extra layer of privacy, you can subscribe using an email anonymization service like Proton Mail’s hide-my-email aliases (10 aliases on the free plan, unlimited on the paid plan), [DuckDuckGo email aliases](https://github.com/Lanshuns/Qwacky), or [addy.io](http://addy.io) (which offers unlimited aliases).
 
 ## Questions?
 

--- a/keystatic.config.tsx
+++ b/keystatic.config.tsx
@@ -559,6 +559,12 @@ export default config({
           ],
           defaultValue: '2',
         }),
+        hideInlineCta: fields.checkbox({
+          label: 'Hide inline newsletter CTA',
+          description:
+            'By default, a compact newsletter signup is inserted after the first section with checklist items. Check to suppress on this guide.',
+          defaultValue: false,
+        }),
         body: fields.mdx({
           label: 'Guide Content',
           options: mdxEditorOptionsContent,
@@ -671,6 +677,12 @@ export default config({
             { label: '3 — ## and ###', value: '3' },
           ],
           defaultValue: '2',
+        }),
+        hideInlineCta: fields.checkbox({
+          label: 'Hide inline newsletter CTA',
+          description:
+            'By default, a compact newsletter signup is inserted between the first and second H2 section. Check to suppress on this page.',
+          defaultValue: false,
         }),
         body: fields.mdx({
           label: 'Body',

--- a/lib/inline-cta-split.js
+++ b/lib/inline-cta-split.js
@@ -1,0 +1,132 @@
+/**
+ * Split MDX content at the point where the inline CTA should be auto-inserted.
+ *
+ * Used by app/[locale]/[...slug]/page.tsx before serializing MDX, so the
+ * CTA can be rendered between two separately-serialized halves of the body.
+ *
+ * Both splitters bail out (didSplit: false) if the content already contains
+ * a manual <InlineCta /> placement, so editors can override the auto location.
+ */
+
+const MANUAL_CTA_RE = /<InlineCta\b/;
+
+/** Find matching closing tag for an opening Section tag, accounting for nesting. */
+function findSectionEnd(content, openTagEndIdx) {
+  const openRe = /<Section\b/g;
+  const closeRe = /<\/Section>/g;
+  openRe.lastIndex = openTagEndIdx;
+  closeRe.lastIndex = openTagEndIdx;
+  let depth = 1;
+  while (depth > 0) {
+    const nextOpen = openRe.exec(content);
+    const nextClose = closeRe.exec(content);
+    if (!nextClose) return -1;
+    if (nextOpen && nextOpen.index < nextClose.index) {
+      depth += 1;
+      closeRe.lastIndex = nextOpen.index + 1;
+    } else {
+      depth -= 1;
+      if (depth === 0) return nextClose.index + '</Section>'.length;
+      openRe.lastIndex = nextClose.index + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Split guide MDX body at the first <Section> whose contents include
+ * a <ChecklistItem> or <ChecklistItemGroup>. Sections that are pure text
+ * (e.g. an introductory section) are skipped — the CTA only appears after
+ * the reader has scrolled past actual checklist content.
+ *
+ * Input: the body chunk that starts at the first <Section (already split
+ * out from frontmatter and the pre-section intro by the page route).
+ * Returns { beforeCta, afterCta, didSplit }.
+ */
+export function splitGuideBodyForCta(content) {
+  if (!content || typeof content !== 'string') {
+    return { beforeCta: content || '', afterCta: '', didSplit: false };
+  }
+  if (MANUAL_CTA_RE.test(content)) {
+    return { beforeCta: content, afterCta: '', didSplit: false };
+  }
+
+  const openTagRe = /<Section\b[^>]*>/g;
+  let match;
+  while ((match = openTagRe.exec(content)) !== null) {
+    const openEnd = match.index + match[0].length;
+    const closeEnd = findSectionEnd(content, openEnd);
+    if (closeEnd === -1) break;
+    const inner = content.slice(openEnd, closeEnd - '</Section>'.length);
+    if (/<ChecklistItem\b|<ChecklistItemGroup\b/.test(inner)) {
+      return {
+        beforeCta: content.slice(0, closeEnd).trim(),
+        afterCta: content.slice(closeEnd).trim(),
+        didSplit: true,
+      };
+    }
+    openTagRe.lastIndex = closeEnd;
+  }
+
+  return { beforeCta: content, afterCta: '', didSplit: false };
+}
+
+/**
+ * Split page MDX at the first H2 boundary so the CTA can sit between the
+ * intro section and the rest of the page. We split *before* the second H2
+ * (i.e. after the first H2's content) so the CTA reads as an aside between
+ * sections rather than at the top.
+ *
+ * Recognizes both markdown `## ` headings and raw `<h2>` tags. Skips
+ * fenced code blocks so a `## ` inside ```...``` is not treated as a heading.
+ */
+export function splitPageContentForCta(content) {
+  if (!content || typeof content !== 'string') {
+    return { beforeCta: content || '', afterCta: '', didSplit: false };
+  }
+  if (MANUAL_CTA_RE.test(content)) {
+    return { beforeCta: content, afterCta: '', didSplit: false };
+  }
+
+  const h2Indices = findH2Indices(content);
+  if (h2Indices.length < 2) {
+    return { beforeCta: content, afterCta: '', didSplit: false };
+  }
+
+  const splitAt = h2Indices[1];
+  return {
+    beforeCta: content.slice(0, splitAt).trim(),
+    afterCta: content.slice(splitAt).trim(),
+    didSplit: true,
+  };
+}
+
+function findH2Indices(content) {
+  const indices = [];
+  const lines = content.split('\n');
+  let offset = 0;
+  let inFence = false;
+  let fenceMarker = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const fenceMatch = trimmed.match(/^(```+|~~~+)/);
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = fenceMatch[1][0];
+      } else if (trimmed.startsWith(fenceMarker)) {
+        inFence = false;
+        fenceMarker = null;
+      }
+    } else if (!inFence) {
+      if (/^##\s+\S/.test(trimmed) && !/^###/.test(trimmed)) {
+        indices.push(offset);
+      } else if (/^<h2[\s>]/i.test(trimmed)) {
+        indices.push(offset);
+      }
+    }
+    offset += line.length + 1;
+  }
+  return indices;
+}

--- a/lib/mdx-components.js
+++ b/lib/mdx-components.js
@@ -30,6 +30,7 @@ import StyledSpan from '@/components/mdx/StyledSpan';
 import MenuPath from '@/components/guides/MenuPath';
 import SimpleImage from '@/components/SimpleImage';
 import TranslationStats from '@/components/TranslationStats';
+import InlineCta from '@/components/InlineCta';
 import { useChecklistItems } from '@/contexts/ChecklistItemsContext';
 import { useSectionContext } from '@/contexts/SectionContext';
 
@@ -173,6 +174,7 @@ export const mdxComponents = {
   MenuPath,
   SimpleImage,
   TranslationStats,
+  InlineCta,
 };
 
 export default mdxComponents;

--- a/lib/mdx-options.js
+++ b/lib/mdx-options.js
@@ -58,6 +58,7 @@ const ALLOWED_COMPONENTS = new Set([
   'MenuPath',
   'SimpleImage',
   'TranslationStats',
+  'InlineCta',
 ]);
 
 // Standard HTML elements that are allowed in MDX

--- a/messages/en.json
+++ b/messages/en.json
@@ -171,6 +171,12 @@
       "emailShort": "Email"
     }
   },
+  "inlineCta": {
+    "heading": "Get new and updated guides by email",
+    "description": "Security advice changes as new surveillance tools emerge and as activists develop new defenses. Subscribe and we'll email you when we publish or update guides.",
+    "buttonText": "Subscribe",
+    "emailAriaLabel": "Email address"
+  },
   "common": {
     "loading": "Loading...",
     "error": "Something went wrong",

--- a/messages/en.json
+++ b/messages/en.json
@@ -172,10 +172,11 @@
     }
   },
   "inlineCta": {
-    "heading": "Get new and updated guides by email",
-    "description": "Security advice changes as new surveillance tools emerge and as activists develop new defenses. Subscribe and we'll email you when we publish or update guides.",
+    "heading": "When their tactics change, our advice does too",
+    "description": "ICE, police, and corporate surveillance keep adding new tools. We update these guides to keep pace. Subscribe to hear when something important shifts.",
     "buttonText": "Subscribe",
-    "emailAriaLabel": "Email address"
+    "emailAriaLabel": "Email address",
+    "privacyLink": "Privacy policy"
   },
   "common": {
     "loading": "Loading...",

--- a/package.json
+++ b/package.json
@@ -123,9 +123,11 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
+    "remark-parse": "^11.0.0",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "unified": "^11.0.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       remark-html:
         specifier: ^16.0.1
         version: 16.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -197,6 +200,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.0)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/scripts/crowdin-hide-strings.mjs
+++ b/scripts/crowdin-hide-strings.mjs
@@ -91,6 +91,7 @@ const UNTRANSLATABLE_FRONTMATTER_SCALARS = [
   "tags",           // comma-separated tag identifiers
   "showToc",        // boolean: layout / “On this page” sidebar (pages)
   "tocDepth",       // 2 or 3: which heading levels appear in the left TOC
+  "hideInlineCta",  // boolean: suppress auto-inserted inline newsletter CTA
 ];
 
 // JSX attributes whose values should not be translated


### PR DESCRIPTION
Auto-inserts a compact Substack-style newsletter signup aside after the
first guide section that contains checklist items (skipping intro-only
text sections), or between the first two H2s on a content page. Reuses
the existing newsletter subscribe hook so signups still flow through
Listmonk.

Editors can suppress per page with hideInlineCta: true in frontmatter,
or place the CTA manually anywhere via the new <InlineCta /> MDX
component (auto-insertion is skipped when a manual one is present).

Also adds unified and remark-parse as explicit dependencies so
Turbopack can resolve them; they were only present as transitive deps,
which broke the dev server.
