### PR TITLE
(DRAFT) Add compact view mode for checklist guides

### DIFF
--- a/__tests__/howto-extract.test.js
+++ b/__tests__/howto-extract.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { extractHowToBlocks, hasHowToBlock } from '../lib/howto-extract';
+
+describe('extractHowToBlocks', () => {
+  it('returns null when no HowTo block is present', () => {
+    expect(extractHowToBlocks('Just some plain text.')).toBeNull();
+    expect(extractHowToBlocks('')).toBeNull();
+    expect(extractHowToBlocks(null)).toBeNull();
+    expect(extractHowToBlocks(undefined)).toBeNull();
+  });
+
+  it('extracts a single HowTo block and strips its title attribute', () => {
+    const input = `Intro paragraph.
+
+<HowTo title="How to do it">
+  Step one.
+
+  Step two.
+</HowTo>
+
+Trailing paragraph.`;
+    const result = extractHowToBlocks(input);
+    expect(result).toContain('<HowTo>');
+    expect(result).not.toContain('title="How to do it"');
+    expect(result).toContain('Step one.');
+    expect(result).toContain('Step two.');
+    expect(result).toContain('</HowTo>');
+    expect(result).not.toContain('Intro paragraph.');
+    expect(result).not.toContain('Trailing paragraph.');
+  });
+
+  it('keeps titles when there are multiple HowTo blocks', () => {
+    const input = `<HowTo title="First">
+  A
+</HowTo>
+
+Between text that should be dropped.
+
+<HowTo title="Second">
+  B
+</HowTo>`;
+    const result = extractHowToBlocks(input);
+    expect(result).toContain('title="First"');
+    expect(result).toContain('title="Second"');
+    expect(result).not.toContain('Between text');
+  });
+
+  it('preserves inner Alert tags', () => {
+    const input = `<HowTo title="X">
+  <Alert type="warning">Heads up</Alert>
+</HowTo>`;
+    const result = extractHowToBlocks(input);
+    expect(result).toContain('<Alert type="warning">Heads up</Alert>');
+  });
+
+  it('handles HowTo without a title attribute', () => {
+    const input = `<HowTo>
+  Untitled content
+</HowTo>`;
+    const result = extractHowToBlocks(input);
+    expect(result).toContain('<HowTo>');
+    expect(result).toContain('Untitled content');
+  });
+});
+
+describe('hasHowToBlock', () => {
+  it('returns true when a HowTo block exists', () => {
+    expect(hasHowToBlock('<HowTo>x</HowTo>')).toBe(true);
+    expect(hasHowToBlock('text <HowTo title="t">x</HowTo> text')).toBe(true);
+  });
+
+  it('returns false otherwise', () => {
+    expect(hasHowToBlock('no how to here')).toBe(false);
+    expect(hasHowToBlock('')).toBe(false);
+    expect(hasHowToBlock(null)).toBe(false);
+  });
+});

--- a/__tests__/view-mode.test.js
+++ b/__tests__/view-mode.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { resolveViewMode, storageKeyForGuide } from '../lib/view-mode-resolver';
+
+describe('resolveViewMode', () => {
+  it('prefers a valid URL param over stored value', () => {
+    expect(resolveViewMode('compact', 'detailed')).toBe('compact');
+    expect(resolveViewMode('detailed', 'compact')).toBe('detailed');
+  });
+
+  it('falls back to stored value when URL param is absent or invalid', () => {
+    expect(resolveViewMode(null, 'compact')).toBe('compact');
+    expect(resolveViewMode(undefined, 'compact')).toBe('compact');
+    expect(resolveViewMode('bogus', 'compact')).toBe('compact');
+  });
+
+  it('defaults to detailed when both inputs are missing or invalid', () => {
+    expect(resolveViewMode(null, null)).toBe('detailed');
+    expect(resolveViewMode('', '')).toBe('detailed');
+    expect(resolveViewMode('garbage', 'also-garbage')).toBe('detailed');
+  });
+});
+
+describe('storageKeyForGuide', () => {
+  it('produces a per-guide namespaced key', () => {
+    expect(storageKeyForGuide('action')).toBe('checklist-view:action');
+    expect(storageKeyForGuide('protest')).toBe('checklist-view:protest');
+  });
+
+  it('keeps different guides isolated', () => {
+    expect(storageKeyForGuide('action')).not.toBe(storageKeyForGuide('protest'));
+  });
+});

--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -23,6 +23,7 @@ import {
   extractChecklistItems,
   serializeFrontmatter,
 } from '@/lib/content';
+import { extractHowToBlocks } from '@/lib/howto-extract';
 import {
   resolveChecklistItem,
   resolveGuide,
@@ -203,9 +204,15 @@ export default async function SlugPage({ params }) {
         if (item) {
           try {
             const serializedItemBody = await serialize(item.content, mdxOptions);
+            const howToSource = extractHowToBlocks(item.content);
+            const serializedHowTo = howToSource
+              ? await serialize(howToSource, mdxOptions)
+              : null;
             checklistItems[itemSlug] = {
               frontmatter: serializeFrontmatter(item.frontmatter),
               serializedBody: serializedItemBody,
+              serializedHowTo,
+              hasHowTo: Boolean(howToSource),
             };
           } catch (err) {
             console.warn(`Failed to serialize checklist item "${itemSlug}":`, err.message);

--- a/components/guides/ChecklistItem.js
+++ b/components/guides/ChecklistItem.js
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { ChevronDown, Check, Link2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -7,6 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { MDXRemote } from 'next-mdx-remote';
 import Markdown from '../Markdown';
 import { Recommendations } from '@/components/guides/Recommendations'
+import { HowTo } from '@/components/guides/HowTo';
 import { IoInformationCircleOutline } from "react-icons/io5";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
@@ -14,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { useAnalytics } from '@/hooks/use-analytics';
 import { useTranslations } from 'next-intl';
 import { migrateLegacyChecklistKeysForSlug } from '@/lib/checklist-storage-migrate';
+import { useViewMode, VIEW_MODES } from '@/contexts/ViewModeContext';
 
 const TITLE_BADGE_VARIANTS = {
   important: "destructive",
@@ -139,6 +141,8 @@ const ChecklistItem = ({
   stop: itemStop,
   titleBadges: itemTitleBadges = [],
   serializedBody,
+  serializedHowTo,
+  hasHowTo = false,
   bodyComponents,
   expandTrigger,
   index,
@@ -155,6 +159,8 @@ const ChecklistItem = ({
   const [enableTransitions, setEnableTransitions] = useState(false);
   const { trackEvent } = useAnalytics();
   const t = useTranslations();
+  const { viewMode } = useViewMode();
+  const isCompact = viewMode === VIEW_MODES.COMPACT;
   const hasTrackedExpansion = useRef(false);
   const cardRef = useRef(null);
   // Use slug-based keys so progress persists across remigrations (not _uid)
@@ -244,6 +250,21 @@ const ChecklistItem = ({
   const handleCheckboxChange = async (checked, shouldCollapseAfterDelay = false) => {
     setCheckedWithStorage(checked);
 
+    if (isCompact) {
+      // In compact mode the body is collapsed by being checked.
+      // Update expand state in the same render batch as the check so the
+      // gray-out and the collapse animate together, not in two steps.
+      // Fire analytics afterwards (don't await — it would split the renders).
+      setExpandedWithStorage(!checked);
+      if (checked) {
+        trackEvent({
+          name: 'checklist_item_checked',
+          data: { item_id: itemSlug },
+        });
+      }
+      return;
+    }
+
     if (checked) {
       // Track the checkbox being checked
       await trackEvent({
@@ -252,24 +273,22 @@ const ChecklistItem = ({
           item_id: itemSlug,
         }
       });
+    }
 
-      // If requested, collapse after a delay to show completion state briefly
-      if (shouldCollapseAfterDelay && isExpanded) {
+    if (checked && shouldCollapseAfterDelay && isExpanded) {
+      // Scroll to keep the collapsed item visible at the top with buffer
+      if (cardRef.current) {
+        const headerHeight = 80; // Approximate header/nav height buffer
+        const cardTop = cardRef.current.getBoundingClientRect().top + window.scrollY;
+        const targetScrollPosition = cardTop - headerHeight;
 
-        // Scroll to keep the collapsed item visible at the top with buffer
-        if (cardRef.current) {
-          const headerHeight = 80; // Approximate header/nav height buffer
-          const cardTop = cardRef.current.getBoundingClientRect().top + window.scrollY;
-          const targetScrollPosition = cardTop - headerHeight;
-          
-          window.scrollTo({
-            top: Math.max(0, targetScrollPosition),
-            behavior: 'smooth'
-          });
-        }
-
-        setExpandedWithStorage(false);
+        window.scrollTo({
+          top: Math.max(0, targetScrollPosition),
+          behavior: 'smooth'
+        });
       }
+
+      setExpandedWithStorage(false);
     }
   };
 
@@ -289,6 +308,142 @@ const ChecklistItem = ({
       }
     });
   };
+
+  // Compact-mode MDX components: hide info/success Alerts; render HowTo without its inner surface.
+  const compactBodyComponents = useMemo(() => {
+    if (!bodyComponents) return bodyComponents;
+    const BaseAlert = bodyComponents.Alert;
+    return {
+      ...bodyComponents,
+      HowTo: (props) => <HowTo {...props} compact />,
+      Alert: (props) => {
+        const v = props.type ?? props.variant ?? 'default';
+        if (v !== 'warning' && v !== 'error') return null;
+        return BaseAlert ? <BaseAlert {...props} /> : null;
+      },
+    };
+  }, [bodyComponents]);
+
+  if (isCompact) {
+    const compactBodyVisible = !isChecked || isExpanded;
+    return (
+      <Card
+        ref={cardRef}
+        className={cn(
+          "checklist-item checklist-item--compact",
+          "shadow-none rounded-none border-muted border-b-0 border-r-0 border-l-0 border-t",
+          "bg-transparent",
+          "py-5 px-3 md:px-5",
+        )}
+      >
+        <div className="flex gap-3 items-start">
+          <div
+            className={cn(
+              "w-5 h-5 shrink-0 relative mt-0.5",
+            )}
+          >
+            {itemType === 'info' ? (
+              <InfoItemIcon />
+            ) : (
+              <Checkbox
+                checked={isChecked}
+                onCheckedChange={(checked) => handleCheckboxChange(checked, false)}
+                className={cn(
+                  "h-5 w-5 cursor-pointer rounded-sm transition-colors duration-300 border-2",
+                )}
+              />
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <h3
+              className={cn(
+                "mt-0 mb-0 text-lg font-semibold tracking-tight leading-snug",
+                isChecked && "text-muted-foreground",
+                isChecked && `opacity-${checkedOpacity}`,
+              )}
+              id={hasMounted ? itemSlug : undefined}
+              data-slug={itemSlug}
+            >
+              {itemTitleBadges && itemTitleBadges.length > 0 && (
+                <>
+                  {itemTitleBadges.map((badgeType, idx) => {
+                    const variant = TITLE_BADGE_VARIANTS[badgeType];
+                    if (!variant) return null;
+                    return (
+                      <Badge
+                        key={idx}
+                        variant={variant}
+                        className={cn(
+                          "text-xs inline mr-2 align-middle",
+                          isChecked && "opacity-50"
+                        )}
+                      >
+                        {t('checklistItem.importantBadge')}
+                      </Badge>
+                    );
+                  })}
+                </>
+              )}
+              {itemTitle}
+            </h3>
+
+            {isChecked && itemType !== 'info' && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setExpandedWithStorage(!isExpanded);
+                }}
+                aria-expanded={compactBodyVisible}
+                aria-controls={`checklist-body-${itemSlug}`}
+                className={cn(
+                  "mt-1 inline-flex items-center gap-1 self-start text-sm",
+                  "text-muted-foreground hover:text-primary",
+                  "transition-colors duration-200",
+                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm",
+                  "print:hidden",
+                )}
+              >
+                <ChevronDown
+                  aria-hidden
+                  className={cn(
+                    "h-4 w-4 transition-transform duration-300",
+                    compactBodyVisible && "rotate-180",
+                  )}
+                />
+                {compactBodyVisible ? t('checklistView.hideDetails') : t('checklistView.showDetails')}
+              </button>
+            )}
+
+            <div
+              id={`checklist-body-${itemSlug}`}
+              className={cn(
+                "grid",
+                enableTransitions ? "transition-all duration-300" : "transition-none",
+                compactBodyVisible ? "grid-rows-[1fr] mt-2 opacity-100" : "grid-rows-[0fr] mt-0 opacity-0",
+              )}
+            >
+              <div className="overflow-hidden">
+                <div className={cn(
+                  "prose prose-slate max-w-none prose-sm",
+                  isChecked && "text-muted-foreground",
+                )}>
+                  {hasHowTo && serializedHowTo ? (
+                    <MDXRemote {...serializedHowTo} components={compactBodyComponents} />
+                  ) : (
+                    serializedBody && (
+                      <MDXRemote {...serializedBody} components={compactBodyComponents} />
+                    )
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <Card

--- a/components/guides/Guide.js
+++ b/components/guides/Guide.js
@@ -7,6 +7,8 @@ import { Clock, Calendar } from 'lucide-react';
 import { useTranslations, useLocale } from 'next-intl';
 import { mdxComponents } from '@/lib/mdx-components';
 import { ChecklistItemsContext } from '@/contexts/ChecklistItemsContext';
+import { ViewModeProvider } from '@/contexts/ViewModeContext';
+import GuideViewToggle from '@/components/guides/GuideViewToggle';
 import { FeedbackCTA } from '@/components/guides/FeedbackCTA';
 import InlineCta from '@/components/InlineCta';
 import { useLayout } from '@/contexts/LayoutContext';
@@ -80,6 +82,7 @@ export default function Guide({
 
   return (
     <ChecklistItemsContext.Provider value={checklistItems}>
+      <ViewModeProvider guideSlug={slug}>
       {/* Header */}
       <div className="relative bg-linear-to-r from-primary/15 via-primary/10 to-transparent dark:from-primary/40 dark:via-primary/25 rounded-lg px-6 py-6 mb-6 overflow-hidden print:bg-transparent print:p-0 print:mb-2">
         <div className="absolute top-1.5 bottom-1.5 right-3 aspect-square flex items-center justify-center pointer-events-none print:hidden">
@@ -101,6 +104,10 @@ export default function Guide({
             ))}
           </div>
         )}
+      </div>
+
+      <div className="mb-4 flex justify-end print:hidden">
+        <GuideViewToggle />
       </div>
 
       <PageNotices initialNotices={notices} />
@@ -126,6 +133,7 @@ export default function Guide({
           <FeedbackCTA />
         </div>
       </div>
+      </ViewModeProvider>
     </ChecklistItemsContext.Provider>
   );
 }

--- a/components/guides/GuideViewToggle.jsx
+++ b/components/guides/GuideViewToggle.jsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { Rows3, ListChecks } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useViewMode, VIEW_MODES } from '@/contexts/ViewModeContext';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+
+/**
+ * Segmented control for switching between detailed and compact checklist views.
+ * Reads/writes view mode through ViewModeContext.
+ */
+export default function GuideViewToggle({ className }) {
+  const t = useTranslations();
+  const { viewMode, setViewMode } = useViewMode();
+
+  const options = [
+    {
+      value: VIEW_MODES.DETAILED,
+      label: t('checklistView.detailed'),
+      tooltip: t('checklistView.detailedTooltip'),
+      Icon: Rows3,
+    },
+    {
+      value: VIEW_MODES.COMPACT,
+      label: t('checklistView.compact'),
+      tooltip: t('checklistView.compactTooltip'),
+      Icon: ListChecks,
+    },
+  ];
+
+  const onKeyDown = (e) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const idx = options.findIndex((o) => o.value === viewMode);
+    const next = e.key === 'ArrowRight'
+      ? options[(idx + 1) % options.length]
+      : options[(idx - 1 + options.length) % options.length];
+    setViewMode(next.value);
+  };
+
+  return (
+    <TooltipProvider delayDuration={0} skipDelayDuration={1000} disableHoverableContent>
+      <div
+        role="group"
+        aria-label={t('checklistView.toggleLabel')}
+        onKeyDown={onKeyDown}
+        className={cn(
+          "inline-flex items-center rounded-md border border-border bg-background p-0.5 print:hidden",
+          className,
+        )}
+      >
+        {options.map(({ value, label, tooltip, Icon }) => {
+          const isActive = value === viewMode;
+          return (
+            <Tooltip key={value}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setViewMode(value)}
+                  aria-pressed={isActive}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-sm",
+                    "transition-colors duration-150",
+                    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                    isActive
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  <Icon aria-hidden className="h-4 w-4" />
+                  <span>{label}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                sideOffset={6}
+                className="max-w-xs text-center animate-none data-[state=closed]:animate-none"
+              >
+                {tooltip}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/components/guides/GuideViewToggle.jsx
+++ b/components/guides/GuideViewToggle.jsx
@@ -2,10 +2,12 @@
 
 import React from 'react';
 import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 import { Rows3, ListChecks } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useViewMode, VIEW_MODES } from '@/contexts/ViewModeContext';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { useAnalytics } from '@/hooks/use-analytics';
 
 /**
  * Segmented control for switching between detailed and compact checklist views.
@@ -13,7 +15,21 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/comp
  */
 export default function GuideViewToggle({ className }) {
   const t = useTranslations();
+  const pathname = usePathname();
   const { viewMode, setViewMode } = useViewMode();
+  const { trackEvent } = useAnalytics();
+
+  const handleSelect = (value) => {
+    if (value === viewMode) return;
+    setViewMode(value);
+    trackEvent({
+      name: 'checklist_view_mode_changed',
+      data: {
+        view_mode: value,
+        path: pathname,
+      },
+    });
+  };
 
   const options = [
     {
@@ -37,7 +53,7 @@ export default function GuideViewToggle({ className }) {
     const next = e.key === 'ArrowRight'
       ? options[(idx + 1) % options.length]
       : options[(idx - 1 + options.length) % options.length];
-    setViewMode(next.value);
+    handleSelect(next.value);
   };
 
   return (
@@ -58,7 +74,7 @@ export default function GuideViewToggle({ className }) {
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={() => setViewMode(value)}
+                  onClick={() => handleSelect(value)}
                   aria-pressed={isActive}
                   className={cn(
                     "inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-sm",

--- a/components/guides/HowTo.js
+++ b/components/guides/HowTo.js
@@ -5,8 +5,26 @@ import { Settings } from "lucide-react";
 
 /**
  * HowTo — <HowTo title="...">markdown children</HowTo>
+ *
+ * `compact` drops the inner surface, the "How to" title, and the gear icon,
+ * leaving just the prose children. The parent card already provides the surface.
  */
-export const HowTo = ({ title, children }) => {
+export const HowTo = ({ title, children, compact = false }) => {
+
+  if (compact) {
+    return (
+      <div className="how-to-container how-to-container--compact mt-3 first:mt-0">
+        {title && (
+          <h4 className="text-sm! font-semibold! mb-2! uppercase tracking-tight text-muted-foreground">
+            {title}
+          </h4>
+        )}
+        <div className="prose prose-slate max-w-none">
+          {children}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={cn(
@@ -15,7 +33,7 @@ export const HowTo = ({ title, children }) => {
       "mt-4 first:mt-0",
     )}>
       <div
-       
+
         className={cn(
           "how-to mb-2 px-4 pb-4 md:px-6 relative",
           "bg-background",

--- a/contexts/ViewModeContext.js
+++ b/contexts/ViewModeContext.js
@@ -1,0 +1,80 @@
+'use client';
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  VIEW_MODES,
+  isValidViewMode,
+  resolveViewMode,
+  storageKeyForGuide,
+} from '@/lib/view-mode-resolver';
+
+/**
+ * Per-guide view mode: 'detailed' (default) or 'compact'.
+ *
+ * Persistence:
+ *   - URL query param `?view=compact` (shareable; omitted in detailed mode)
+ *   - localStorage key `checklist-view:{guideSlug}` (per-guide, not global)
+ *
+ * Resolution on mount: URL > localStorage > 'detailed'.
+ * Toggling writes both.
+ */
+
+const ViewModeContext = createContext({
+  viewMode: VIEW_MODES.DETAILED,
+  setViewMode: () => {},
+});
+
+export function ViewModeProvider({ guideSlug, children }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Initial paint: use URL only (server can read it). localStorage hydrates post-mount.
+  const urlParam = searchParams.get('view');
+  const initial = isValidViewMode(urlParam) ? urlParam : VIEW_MODES.DETAILED;
+  const [viewMode, setViewModeState] = useState(initial);
+
+  useEffect(() => {
+    if (!guideSlug) return;
+    let stored = null;
+    try {
+      stored = localStorage.getItem(storageKeyForGuide(guideSlug));
+    } catch {}
+    const resolved = resolveViewMode(urlParam, stored);
+    if (resolved !== viewMode) setViewModeState(resolved);
+    // Mount-only: react to guide changes. URL-driven changes from our own
+    // setViewMode call avoid a race where the URL hasn't repainted yet.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [guideSlug]);
+
+  const setViewMode = useCallback(
+    (next) => {
+      if (!isValidViewMode(next)) return;
+      setViewModeState(next);
+      if (guideSlug) {
+        try {
+          localStorage.setItem(storageKeyForGuide(guideSlug), next);
+        } catch {}
+      }
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === VIEW_MODES.DETAILED) params.delete('view');
+      else params.set('view', next);
+      const qs = params.toString();
+      const url = qs ? `${pathname}?${qs}` : pathname;
+      router.replace(url, { scroll: false });
+    },
+    [guideSlug, pathname, router, searchParams]
+  );
+
+  return (
+    <ViewModeContext.Provider value={{ viewMode, setViewMode }}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+}
+
+export function useViewMode() {
+  return useContext(ViewModeContext);
+}
+
+export { VIEW_MODES };

--- a/contexts/ViewModeContext.js
+++ b/contexts/ViewModeContext.js
@@ -1,6 +1,5 @@
 'use client';
 import { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   VIEW_MODES,
   isValidViewMode,
@@ -17,6 +16,10 @@ import {
  *
  * Resolution on mount: URL > localStorage > 'detailed'.
  * Toggling writes both.
+ *
+ * Reads/writes the URL via `window.location` + `history.replaceState` rather
+ * than next/navigation, so this provider doesn't trigger Next.js static-gen
+ * bailouts from `useSearchParams()`.
  */
 
 const ViewModeContext = createContext({
@@ -24,15 +27,30 @@ const ViewModeContext = createContext({
   setViewMode: () => {},
 });
 
-export function ViewModeProvider({ guideSlug, children }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+function readUrlParam() {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get('view');
+}
 
-  // Initial paint: use URL only (server can read it). localStorage hydrates post-mount.
-  const urlParam = searchParams.get('view');
-  const initial = isValidViewMode(urlParam) ? urlParam : VIEW_MODES.DETAILED;
-  const [viewMode, setViewModeState] = useState(initial);
+function writeUrlParam(value) {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (value === VIEW_MODES.DETAILED) {
+    url.searchParams.delete('view');
+  } else {
+    url.searchParams.set('view', value);
+  }
+  // Drop a trailing `?` if there are no params.
+  const newUrl = url.searchParams.toString()
+    ? `${url.pathname}?${url.searchParams.toString()}${url.hash}`
+    : `${url.pathname}${url.hash}`;
+  window.history.replaceState(null, '', newUrl);
+}
+
+export function ViewModeProvider({ guideSlug, children }) {
+  // Server render and first client paint default to 'detailed'.
+  // After mount we resolve URL > localStorage > default.
+  const [viewMode, setViewModeState] = useState(VIEW_MODES.DETAILED);
 
   useEffect(() => {
     if (!guideSlug) return;
@@ -40,10 +58,8 @@ export function ViewModeProvider({ guideSlug, children }) {
     try {
       stored = localStorage.getItem(storageKeyForGuide(guideSlug));
     } catch {}
-    const resolved = resolveViewMode(urlParam, stored);
+    const resolved = resolveViewMode(readUrlParam(), stored);
     if (resolved !== viewMode) setViewModeState(resolved);
-    // Mount-only: react to guide changes. URL-driven changes from our own
-    // setViewMode call avoid a race where the URL hasn't repainted yet.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [guideSlug]);
 
@@ -56,14 +72,9 @@ export function ViewModeProvider({ guideSlug, children }) {
           localStorage.setItem(storageKeyForGuide(guideSlug), next);
         } catch {}
       }
-      const params = new URLSearchParams(searchParams.toString());
-      if (next === VIEW_MODES.DETAILED) params.delete('view');
-      else params.set('view', next);
-      const qs = params.toString();
-      const url = qs ? `${pathname}?${qs}` : pathname;
-      router.replace(url, { scroll: false });
+      writeUrlParam(next);
     },
-    [guideSlug, pathname, router, searchParams]
+    [guideSlug]
   );
 
   return (

--- a/lib/howto-extract.js
+++ b/lib/howto-extract.js
@@ -1,0 +1,40 @@
+/**
+ * Extract `<HowTo>...</HowTo>` blocks from a checklist item's MDX source.
+ *
+ * Returns the concatenation of all top-level HowTo blocks (separated by blank lines)
+ * so the compact view can render just those, or `null` if the source has none.
+ *
+ * The regex is intentionally simple — it doesn't try to handle `>` characters inside
+ * attribute values, because our content uses simple titles ("How to do X"). HowTos
+ * are also not expected to be nested.
+ */
+const HOWTO_PATTERN = '<HowTo\\b[^>]*>[\\s\\S]*?<\\/HowTo>';
+const HOWTO_TITLE_ATTR = /\s+title="[^"]*"/;
+
+/**
+ * Strip the `title` attribute from a single `<HowTo ...>` opening tag.
+ * In single-HowTo items the title is redundant with the checklist item title;
+ * in multi-HowTo items we keep the titles so the blocks can be distinguished.
+ */
+function stripTitleAttribute(howToBlock) {
+  return howToBlock.replace(/^<HowTo\b[^>]*>/, (openingTag) =>
+    openingTag.replace(HOWTO_TITLE_ATTR, ''),
+  );
+}
+
+export function extractHowToBlocks(mdxSource) {
+  if (typeof mdxSource !== 'string' || mdxSource.length === 0) return null;
+  const matches = mdxSource.match(new RegExp(HOWTO_PATTERN, 'g'));
+  if (!matches || matches.length === 0) return null;
+  // Single HowTo: drop its title (the item title already says what it is).
+  // Multiple HowTos: keep titles so blocks can be told apart.
+  if (matches.length === 1) {
+    return stripTitleAttribute(matches[0]);
+  }
+  return matches.join('\n\n');
+}
+
+export function hasHowToBlock(mdxSource) {
+  if (typeof mdxSource !== 'string' || mdxSource.length === 0) return false;
+  return new RegExp(HOWTO_PATTERN).test(mdxSource);
+}

--- a/lib/mdx-components.js
+++ b/lib/mdx-components.js
@@ -123,7 +123,7 @@ function ChecklistItemMdx({ slug, ...overrides }) {
     return null;
   }
 
-  const { frontmatter, serializedBody } = item;
+  const { frontmatter, serializedBody, serializedHowTo, hasHowTo } = item;
 
   return (
     <ChecklistItemComponent
@@ -135,6 +135,8 @@ function ChecklistItemMdx({ slug, ...overrides }) {
       stop={frontmatter.dont ?? frontmatter.stop}
       titleBadges={frontmatter.titleBadges ?? frontmatter.title_badges ?? []}
       serializedBody={serializedBody}
+      serializedHowTo={serializedHowTo}
+      hasHowTo={hasHowTo}
       bodyComponents={checklistItemBodyComponents}
       expandTrigger={expandTrigger}
       {...overrides}

--- a/lib/view-mode-resolver.js
+++ b/lib/view-mode-resolver.js
@@ -1,0 +1,30 @@
+/**
+ * Pure helpers for the checklist view-mode feature.
+ * Kept separate from the React context so they can be imported by tests
+ * without pulling in JSX.
+ */
+
+export const VIEW_MODES = {
+  DETAILED: 'detailed',
+  COMPACT: 'compact',
+};
+
+const VALID_MODES = new Set([VIEW_MODES.DETAILED, VIEW_MODES.COMPACT]);
+const STORAGE_PREFIX = 'checklist-view:';
+
+export function storageKeyForGuide(guideSlug) {
+  return `${STORAGE_PREFIX}${guideSlug}`;
+}
+
+/**
+ * Resolve initial view mode: URL > localStorage > 'detailed'.
+ */
+export function resolveViewMode(urlParam, storedValue) {
+  if (urlParam && VALID_MODES.has(urlParam)) return urlParam;
+  if (storedValue && VALID_MODES.has(storedValue)) return storedValue;
+  return VIEW_MODES.DETAILED;
+}
+
+export function isValidViewMode(value) {
+  return VALID_MODES.has(value);
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -267,6 +267,15 @@
     "collapse": "Collapse",
     "importantBadge": "Important"
   },
+  "checklistView": {
+    "toggleLabel": "Checklist view",
+    "detailed": "Detailed",
+    "detailedTooltip": "Full context with explanations, recommendations, and tools for each item.",
+    "compact": "Compact",
+    "compactTooltip": "Just titles and step-by-step instructions — best for quickly checking items off.",
+    "showDetails": "Show details",
+    "hideDetails": "Hide details"
+  },
   "copyButton": {
     "copy": "Copy",
     "copyText": "Copy text",

--- a/messages/en.json
+++ b/messages/en.json
@@ -272,7 +272,7 @@
     "detailed": "Detailed",
     "detailedTooltip": "Full context with explanations, recommendations, and tools for each item.",
     "compact": "Compact",
-    "compactTooltip": "Just titles and step-by-step instructions — best for quickly checking items off.",
+    "compactTooltip": "Just titles and step-by-step instructions. Best for quickly checking items off.",
     "showDetails": "Show details",
     "hideDetails": "Hide details"
   },


### PR DESCRIPTION
Adds a per-guide Detailed/Compact toggle below the page title. Compact
mode renders each checklist item as a flat row with checkbox + title +
HowTo body (or full body when no HowTo), stripping recommendations,
info-level alerts, and the mark-as-done button. Warning and error
alerts are kept; title badges are preserved.

Persistence: ?view=compact URL param plus per-guide localStorage key
(checklist-view:{slug}) so each guide remembers independently and a
URL with ?view=compact is shareable.

Checking an item in compact mode collapses its body in the same
animated way as detailed; the body re-expands on uncheck, or via a
"Show details / Hide details" toggle while still checked. Analytics
on check still fire in compact mode.

HowTo gains a compact prop that drops its inner surface, gear icon,
and the "How to" heading. When an item has a single HowTo block the
heading is stripped at extraction time (redundant with the item
title); items with multiple HowTo blocks keep their headings so the
blocks remain distinguishable.

Toggle buttons get instant tooltips explaining each mode, with
sibling-swap working across the full button hit area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle to switch between detailed and compact checklist views with keyboard navigation support (arrow keys)
  * View mode preference persists across sessions via URL and local storage

* **Tests**
  * Added test coverage for HowTo block extraction and view mode resolution logic

* **Localization**
  * Added translation strings for the new checklist view mode toggle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ActivistChecklist/ActivistChecklist/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->