### PR TITLE
Rewrite Proton page as a how-to-use-it-safely guide

### DIFF
--- a/content/en/changelog/2026-05-22-proton-safety-guide.mdx
+++ b/content/en/changelog/2026-05-22-proton-safety-guide.mdx
@@ -1,0 +1,6 @@
+---
+type: major
+date: 2026-05-22
+---
+
+**New page:** [How to use Proton safely](/proton/). A full guide to what's encrypted and what isn't on Proton Mail, Docs, and VPN, common misunderstandings, and when to use other tools instead.

--- a/content/en/checklist-items/email.mdx
+++ b/content/en/checklist-items/email.mdx
@@ -11,6 +11,6 @@ titleBadges: []
 
   **Option 2: Create a new email account**
 
-  1. Create a **separate email account** (we recommend [Proton Mail](https://proton.me/mail))
+  1. Create a **separate email account** (we recommend [Proton Mail](https://proton.me/mail); see our [guide to using Proton safely](/proton/))
   2. Use a [random username generator](https://strongphrase.net/username) to help this account be less strongly tied to your identity. (Again, we’re not aiming for total anonymity, but we are trying to create a bit of a buffer.)
 </HowTo>

--- a/content/en/checklist-items/emergency-contacts.mdx
+++ b/content/en/checklist-items/emergency-contacts.mdx
@@ -30,7 +30,7 @@ Having all these contacts in one organized place saves precious time during an e
   **Where to store this information:**
 
   1. Save it to your phone contacts list (if it is not already there)
-  2. Save it in a sharable online document so your other emergency contacts can get access to it (we recommend Proton Docs).
+  2. Save it in a sharable online document so your other emergency contacts can get access to it (we recommend [Proton Docs](https://proton.me/drive/docs); see our [guide to using Proton safely](/proton/)).
   3. Write it down on paper and store in a safe place as backup.
 </HowTo>
 

--- a/content/en/checklist-items/planning-checklist.mdx
+++ b/content/en/checklist-items/planning-checklist.mdx
@@ -9,7 +9,7 @@ Follow the steps below to create a comprehensive reference document that serves 
 </Alert>
 
 <HowTo title="How to complete the safety planning worksheet">
-  1. **Document:** You may find it helpful to use this [Safety Planning Worksheet Template](https://cryptpad.fr/pad/#/2/pad/view/elteCzJEc5ldJSzFUg10S+PALfu5qSgFTdSWLTQobjE/) to organize your responses in one place. You can write down your information on paper or use an end-to-end encrypted platform [Proton Docs](https://proton.me/drive/docs).
+  1. **Document:** You may find it helpful to use this [Safety Planning Worksheet Template](https://cryptpad.fr/pad/#/2/pad/view/elteCzJEc5ldJSzFUg10S+PALfu5qSgFTdSWLTQobjE/) to organize your responses in one place. You can write down your information on paper or use an end-to-end encrypted platform [Proton Docs](https://proton.me/drive/docs) (see our [guide to using Proton safely](/proton/)).
   2. **List all emergency contacts** (see Section 2)
   3. **Document location of important papers**
      * Driver's license, state ID, passport

--- a/content/en/checklist-items/proton-docs-mail.mdx
+++ b/content/en/checklist-items/proton-docs-mail.mdx
@@ -48,5 +48,5 @@ Encrypted cloud tools like [Proton Mail](https://proton.me/mail), [Drive](https:
 [CryptPad](https://cryptpad.fr/) is another popular encrypted doc option, but it is very difficult to use. If it has features you need, it accomplishes the same result.
 
 <Alert type="info">
-  **Proton concerns:** While there have been concerns about Proton's CEO, [we still believe it is a worthwhile tool to use](/proton/). Your risk tolerance may vary.
+  **Using Proton safely:** Proton is a big upgrade over Gmail/Google Docs, but it has real limitations you should know about. See our [guide to using Proton safely](/proton/) for what's encrypted, what's not, and how to avoid common pitfalls.
 </Alert>

--- a/content/en/checklist-items/share-media.mdx
+++ b/content/en/checklist-items/share-media.mdx
@@ -8,6 +8,6 @@ titleBadges: []
 ---
 Signal is the best option because it removes metadata (like location, phone model, and date/time). It also offers an [editing tool to blur faces](https://signal.org/blog/blur-tools/).
 
-If the files are too big for Signal, we recommend [Proton Drive](https://proton.me/drive/).
+If the files are too big for Signal, we recommend [Proton Drive](https://proton.me/drive/) (see our [guide to using Proton safely](/proton/)).
 
 Advanced users can also try out [Onion Share](https://onionshare.org/) for more anonymity.

--- a/content/en/checklist-items/vpn.mdx
+++ b/content/en/checklist-items/vpn.mdx
@@ -31,7 +31,7 @@ A VPN with ad-blocking enabled is especially important on your phone.
 
 * [**Mullvad VPN**](https://mullvad.net/en/vpn) **(top recommendation)**: Better privacy since payment info isn't stored, but you need to manually pay each cycle.
 * [**IVPN**](https://www.ivpn.net/en/) can be easier because it automatically renews.
-* [**Proton VPN**](https://protonvpn.com/) has a solid free plan, but it is only for 1 device. To get ad-blocking, you need a paid plan. (See our [note](/proton/) regarding concerns about the Proton CEO and why we still offer Proton options.)
+* [**Proton VPN**](https://protonvpn.com/) has a solid free plan, but it is only for 1 device. To get ad-blocking, you need a paid plan. (If you use Proton, see our [guide to using Proton safely](/proton/).)
 
 <HowTo title="How to set up Mullvad VPN">
   ***Mobile app***

--- a/content/en/guides/secondary.mdx
+++ b/content/en/guides/secondary.mdx
@@ -74,7 +74,7 @@ Here’s a list of some of the kinds of data on your phone that might be worth p
 * **Maintenance:** 30 minutes after each use
 
 <Section title="Setup Guide">
-  **If you want the tl;dr version of this guide:** Get a phone. Make sure it's unlocked. Go to a store in-person to buy a [SIM card](https://www.bestbuy.com/product/tracfone-bring-your-own-phone-mini-sim-pack-with-nano-micro-standard-multi/JXJCJWVFF4) and a [service plan](https://www.bestbuy.com/product/tracfone-99-99-basic-phone-400-minutes-for-talk-text-data-365-days-prepaid-plan-email-delivery-white-digital/JXJCJWPGP2) in cash. Make an email account on Proton Mail and use that when you need to make an account with your cell provider and Apple/Google. Don't use your real email/phone to register anything. Activate the phone. Install Signal.
+  **If you want the tl;dr version of this guide:** Get a phone. Make sure it's unlocked. Go to a store in-person to buy a [SIM card](https://www.bestbuy.com/product/tracfone-bring-your-own-phone-mini-sim-pack-with-nano-micro-standard-multi/JXJCJWVFF4) and a [service plan](https://www.bestbuy.com/product/tracfone-99-99-basic-phone-400-minutes-for-talk-text-data-365-days-prepaid-plan-email-delivery-white-digital/JXJCJWPGP2) in cash. Make an email account on Proton Mail (see our [guide to using Proton safely](/proton/)) and use that when you need to make an account with your cell provider and Apple/Google. Don't use your real email/phone to register anything. Activate the phone. Install Signal.
 
   <ChecklistItemGroup>
     <ChecklistItem slug="cell-provider" />

--- a/content/en/pages/proton.mdx
+++ b/content/en/pages/proton.mdx
@@ -6,21 +6,19 @@ firstPublished: 2025-08-21
 lastUpdated: 2026-05-22
 ---
 
-**Bottom line up front:**
-
 This article helps you think through whether using Proton Mail/Docs/Drive is the right tool for your needs, and how to use it safely if you end up deciding to use it.
+
+**When using Proton might be a good fit:**
 
 * If you want secure messaging, use Signal rather than Proton Mail. But if you have things to do over email (as most of us do), Proton Mail ensures the contents of your emails can't be turned over to the cops if you're emailing with other Proton users. (Gmail does not.)
 * If you collaborate with other users on drafting documents or sharing info in spreadsheets, with Proton Docs and Spreadsheets the contents of your docs can't be turned over to law enforcement (though the email addresses that doc collaborators access them with *can* be). Google Workspace does not.
 * If you need a free [VPN](/essentials/#vpn), Proton VPN is safe and fast, although we mainly recommend Mullvad VPN, a paid service.
-* If you want to use Proton's services anonymously:
-  * Make sure you complete setup using [Tor Browser](https://www.torproject.org/download/), never enter a credit card, and never enter an email/phone as your recovery info. Then, always access Proton using Tor Browser and never any other browser.
-  * Be mindful at all times that information about the accounts you are emailing or sharing docs with can always be turned over to the cops.
+* If you want to use Proton's services anonymously: Make sure you complete setup using [Tor Browser](https://www.torproject.org/download/), never enter a credit card, and never enter an email/phone as your recovery info. Then, always access Proton using Tor Browser and never any other browser. (More caveats below.)
 
-Why we still include Proton in our recommendations (even though their company sometimes does shitty things):
+**Why we still include Proton in our recommendations (even though their company sometimes does shitty things):**
 
 * Proton Docs is much easier to use than CryptPad, and we think usability matters a lot for people actually using secure tools. And Proton is secure in a way that Google's services are not.
-* All things considered, the concerns about the CEO's comments and missteps by their marketing people in selling the paid services do not affect the nature of the service, which we consider secure, with the caveats we specify below.
+* All things considered, the concerns about the CEO's comments and missteps by their marketing department do not affect the nature of the service, which we consider secure, with the caveats we specify below.
 * The fact that the company is based in Switzerland does not put data out of reach of US agencies, but it may provide a bit more insulation than US-based services.
 
 Many aligned organizations are already using Proton Mail: [Food Not Bombs](https://foodnotbombs.net/), [Waging Nonviolence](http://wagingnonviolence.org/), [PM Press](https://pmpress.org/), [Vision Change Win](https://visionchangewin.org/), [Palestine Legal](https://palestinelegal.org/), [The Intercept](https://theintercept.com/).

--- a/content/en/pages/proton.mdx
+++ b/content/en/pages/proton.mdx
@@ -1,27 +1,252 @@
 ---
-title: Can we trust Proton Mail / Proton VPN?
-seoDescription: Is Proton still safe for activists? After their CEO's controversial Trump comments, we walked through the actual encryption guarantees. Our verdict and why.
+title: How to use Proton safely
+seoTitle: How to use Proton safely as an activist (2026)
+seoDescription: How to use Proton Mail, Proton Docs, and Proton VPN safely as an activist. What is encrypted, what is not, common misunderstandings, and when to use other tools instead.
 firstPublished: 2025-08-21
-lastUpdated: 2025-10-21
+lastUpdated: 2026-05-22
 ---
-Across the site, we recommend [Proton](https://proton.me/) products like Proton VPN, Proton Mail, and Proton Docs for end-to-end encrypted documents.
 
-## Concerns about Proton
+**Bottom line up front:**
 
-In January 2025, Proton's CEO [praised a Trump appointee](https://theintercept.com/2025/01/28/proton-mail-andy-yen-trump-republicans/).
+This article helps you think through whether using Proton Mail/Docs/Drive is the right tool for your needs, and how to use it safely if you end up deciding to use it.
 
-Some interpreted this as a sign that Proton was aligning themselves with authoritarian forces and that our data was no longer safe there. We take a different stance.
+* If you want secure messaging, use Signal rather than Proton Mail. But if you have things to do over email (as most of us do), Proton Mail ensures the contents of your emails can't be turned over to the cops if you're emailing with other Proton users. (Gmail does not.)
+* If you collaborate with other users on drafting documents or sharing info in spreadsheets, with Proton Docs and Spreadsheets the contents of your docs can't be turned over to law enforcement (though the email addresses that doc collaborators access them with *can* be). Google Workspace does not.
+* If you need a free [VPN](/essentials/#vpn), Proton VPN is safe and fast, although we mainly recommend Mullvad VPN, a paid service.
+* If you want to use Proton's services anonymously:
+  * Make sure you complete setup using [Tor Browser](https://www.torproject.org/download/), never enter a credit card, and never enter an email/phone as your recovery info. Then, always access Proton using Tor Browser and never any other browser.
+  * Be mindful at all times that information about the accounts you are emailing or sharing docs with can always be turned over to the cops.
 
-## We think Proton is still a trustworthy option
+Why we still include Proton in our recommendations (even though their company sometimes does shitty things):
 
-After investigating this, we've decided to continue recommending certain Proton services. While concerning, we view this as an unfortunate misstep rather than a threat to user privacy or data security. We don't see it as a pattern, but as a wildly tone-deaf choice.
+* Proton Docs is much easier to use than CryptPad, and we think usability matters a lot for people actually using secure tools. And Proton is secure in a way that Google's services are not.
+* All things considered, the concerns about the CEO's comments and missteps by their marketing people in selling the paid services do not affect the nature of the service, which we consider secure, with the caveats we specify below.
+* The fact that the company is based in Switzerland does not put data out of reach of US agencies, but it may provide a bit more insulation than US-based services.
 
-We believe in recommending tools that balance strong security with usability. We want to suggest tools that people will actually adopt and use consistently. Proton Mail and Proton Docs are the most user-friendly options for encrypted email and document collaboration. And we include Proton VPN because our users wanted us to list a free VPN option.
+Many aligned organizations are already using Proton Mail: [Food Not Bombs](https://foodnotbombs.net/), [Waging Nonviolence](http://wagingnonviolence.org/), [PM Press](https://pmpress.org/), [Vision Change Win](https://visionchangewin.org/), [Palestine Legal](https://palestinelegal.org/), [The Intercept](https://theintercept.com/).
 
-We will keep an eye on this situation and change our recommendations if Proton continues to make concerning moves.
+<section id="worth-it">
 
-## If you are in a high-risk group...
+## Is Proton a good fit for your needs?
 
-If you are in a very high-risk category of activist (doing very high-profile work, or doing work that is targeted by this administration), you probably want to avoid Proton for sensitive communications. That said, we recommend avoiding any email service for sensitive communications regardless of which service you choose. Those communications should be happening on Signal with disappearing messages turned on.
+Using encrypted email and docs can protect you in a number of situations, but it's not the right choice for everyone.
 
-If you want to put in the work to use a different encrypted email system, there are other options like [Tuta](https://tuta.com/) and [Mailbox.org](https://mailbox.org/).
+✅ Proton **might** be a good option if:
+
+* You are storing email/docs that could put you (and others) in danger if law enforcement got ahold of that information. (Note: If your organization receives a subpoena, you will often have to turn over the data anyway. Proton would only protect you from the cops getting your data without you knowing about it, because the court order came with a gag order.)
+* You are part of a small group of people you can trust to keep their accounts [secure](/essentials/). (Compared to Google, Proton has fewer account protections.)
+* You want easy access to [email aliases](https://proton.me/support/addresses-and-aliases) which help you protect your privacy when signing up for newsletters/services on other sites.
+* You believe that big tech companies like Google are unethical and you want to keep your data somewhere that aligns more with your values.
+
+❌ Proton is probably **not** a good option for you if:
+
+* You don't actually need encryption for your email or docs. If you think that the cops are unlikely to ever try to get a court order for your data, or your data isn't sensitive enough to matter if it was turned over, Gmail and Google Docs are often a fine option because they are easy to use and most people already use them.
+* Targeted account takeover (phishing) is a bigger risk for you than government investigation/subpoena. (Google Workspace has stronger account security protections.)
+* You are trying to remain anonymous. (This is possible with Proton, but you have to be [very careful](#anonymous) in how you use it.)
+* You need the recipients of your messages (or the people shared on your documents) to be fully private. (Consider [Signal](https://signal.org/) or [CryptPad](https://cryptpad.fr/) instead.)
+* You need the Proton team management features, such as using more than 3 "anyone with link can edit" documents but can't pay for them. (Consider [CryptPad](https://cryptpad.fr/) instead.)
+
+</section>
+
+<InlineCta />
+
+<section id="why-useful">
+
+## Why Proton's services are useful for activists
+
+### ✅ Reason #1: Proton offers collaborative docs and spreadsheets that are as easy to use as Google Docs, but fully encrypted
+
+Until Proton Docs was released, we usually had to choose between ease of use (Google Docs) or end-to-end encryption (CryptPad etc).
+
+Google Docs are easy to use, but they're a risk to activists because we know that Google frequently turns over data to law enforcement when the government is seeking to suppress dissent. Google recently started complying with so-called "administrative warrants" from ICE, which don't even require a judge to review them.
+
+There are other encrypted document platforms, like CryptPad, that are popular with activists. CryptPad is encrypted and free, but it has a very difficult user interface and often doesn't work well on mobile.
+
+<mark>Proton offers a good balance of both: the contents of your documents cannot be viewed by law enforcement because they are encrypted AND it has a very user-friendly design.</mark>
+
+We believe that recommending easy-to-use tools is one of the best ways to get more adoption.
+
+### ✅ Reason #2: Proton offers *limited* encrypted email, but it is the most usable encrypted email tool available today
+
+If the cops get a court order to access your Gmail account, Google will readily turn over the data with minimal pushback. If the cops include a gag order, you won't even know this happened until months later. Encrypted email helps protect against this threat.
+
+But let's say the most important thing first: <mark>If your safety depends on the security of your communications, you should use Signal instead of email.</mark>
+
+That said, Proton does offer encrypted email. It covers some of your messages, but not all of them, and it is more limited than their marketing material would have you believe. [See below for the full list of limitations](#limitations).
+
+The more activists that use Proton, the more we make it hard for the cops to access our email when they are seeking to suppress dissent.
+
+### ✅ Reason #3: Proton offers a trustworthy VPN that is free
+
+We strongly recommend folks use [Mullvad](https://mullvad.net/en) (or [IVPN](https://www.ivpn.net/)) if they are able to pay $5/month. But since many activists are tight on funds, we feel it's important to offer a free VPN option. Proton VPN is reasonably fast and trustworthy, as a free option.
+
+</section>
+
+<section id="misunderstandings">
+
+## Common (and potentially dangerous) misunderstandings about Proton
+
+We must understand Proton's limitations in order to use it safely.
+
+<h3 id="anonymous">❌ Misunderstanding #1: You are anonymous when you use Proton</h3>
+
+People often think that "end-to-end encryption" also means that your identity is protected. While this is (mostly) true when using Signal, it's not the case with any email provider because of the way email works. Encryption of messages/docs is not the same as anonymity.
+
+* Every time you access a website, your computer reveals its "IP address", which can be used to identify you as the user. Your browser also reveals something called a "fingerprint" that can be used to identify you. (You can protect yourself from both of these risks by using [Tor Browser](https://www.torproject.org/download/).) A VPN alone will not protect you from browser fingerprinting.
+* If you pay for a Proton subscription using a credit card, they have your identity and can turn it over to the cops. (There are [anonymous payment options](https://digitalgoods.proxysto.re/en) you can use instead.)
+* If you enter your phone number or another email address that is attached to your identity into the recovery info, this information can be turned over.
+* If you enter your full name in the "name" field in settings, you are directly revealing your identity.
+
+**It *is* possible to use Proton anonymously**, but you have to be very deliberate. Always complete setup and access Proton through [Tor Browser](https://www.torproject.org/download/), never use a credit card, and never enter a phone number or recovery email tied to your identity.
+
+<h3 id="limitations">❌ Misunderstanding #2: 100% of your emails are encrypted</h3>
+
+Proton's email encryption only works on the **contents** of the email (not the subject or recipient) AND only when the emails are **between Proton users** (not Gmail or basically any other email provider).
+
+Here's how the encryption actually works, and its limitations:
+
+* **✅ The contents of Proton emails are truly encrypted if and only if you are emailing with another Proton user.** (Or someone who knows how to turn on encryption for their custom domain, which is rare.)
+* ❌ When you email with anyone outside of Proton Mail, the email is entirely unencrypted in their inbox, so it's readable by the provider (like Gmail) and could be accessed by hackers or law enforcement. Note: You can use Proton's [password-protected email](https://proton.me/support/password-protected-emails) feature to protect external emails. This is a good feature to use.
+* ❌ The subject lines and recipient are never encrypted (even when messaging with other Proton users).
+* 🟡 Incoming emails (from any email provider) get encrypted after they arrive in your account, but Proton technically can see them briefly before they get encrypted. There hasn't been a public case of this happening, but they could be compelled to keep an active log of incoming emails (from non-Proton accounts like Gmail) before they get encrypted. This would be a pretty extraordinary step because unlike the publicized case of the [IP address of a climate activist](https://techcrunch.com/2021/09/06/protonmail-logged-ip-address-of-french-activist-after-order-by-swiss-authorities/) being turned over, this would require writing new code.
+
+<h3 id="swiss">❌ Misunderstanding #3: Proton being based in Switzerland protects you from US law enforcement getting your account data</h3>
+
+The US government uses something called a Mutual Legal Assistance Treaty (MLAT) to carry out court orders in other countries.
+
+That means that some of the data on your Proton account is still accessible to US law enforcement, even though the company is based in Switzerland. ([See below for a list of what is encrypted and not encrypted](#encrypted-data).)
+
+There are additional hurdles the cops have to jump, and the Swiss courts have to assess whether the legal request meets their country's laws. If the Swiss courts agree that the request is valid, they will send a court order to Proton and Proton must comply (or face legal/financial consequences).
+
+As we mention below, the fact that Proton turns data over to the cops doesn't say a whole lot about their reputation. They are in the same position as every other web app or service provider: they have to abide by the laws or they will face heavy fines and legal actions. The thing that distinguishes providers is how much they are willing to contest court orders before complying with them.
+
+**Our take: Proton being based in Switzerland does in fact make it harder for the cops to access your data, and that is worthwhile for activists. Just remember that it doesn't *prevent* them from accessing your data.**
+
+That said, the biggest protection you get from using Proton is not from the company being located overseas, it is from your data being encrypted.
+
+</section>
+
+<section id="encrypted-data">
+
+## Summary of what data is encrypted, or not, when using Proton
+
+Knowing what data could be turned over to law enforcement helps you make safe choices when using Proton.
+
+**✅ Encrypted data (can't be turned over to the cops)**
+
+* The contents and titles of your documents/files
+* The contents of your emails with other Proton users
+* The contents of [password-protected emails](https://proton.me/support/password-protected-emails) you send to non-Proton users
+
+**🟡 Partially encrypted, but not fully guaranteed**
+
+* The contents of your emails to and from non-Proton users. These emails get encrypted when they arrive on or leave Proton's servers. But (as mentioned above) they arrive unencrypted, and Proton could theoretically be forced to intercept that unencrypted copy of the email. This has never been publicly reported and we think it is relatively unlikely. If this did happen, it would only apply to new emails. All existing emails would have already been encrypted when they were stored in your inbox.
+
+**❌ Unencrypted data (can be turned over to the cops)**
+
+*Docs:*
+
+* The email addresses of users you've shared the document with (this means a court could compel Proton to turn over all the email addresses shared on any of your documents)
+* File size, file type, modification date
+
+*Email:*
+
+* [Subject lines](https://proton.me/support/does-protonmail-encrypt-email-subjects)
+* The email addresses of anyone you send emails to
+* When the email was sent/received
+* The copy of an email that you sent that arrived in a non-Proton user's inbox (Proton could not turn it over, but the other email provider can read it and turn it over)
+
+*Account:*
+
+* Your IP Address
+* The phone number or email address you set as your "recovery info" for your account ([example case](https://cyberinsider.com/protonmail-discloses-user-data-leading-to-arrest-in-spain/))
+* Your credit card (if you are on a paid plan)
+
+</section>
+
+<section id="dislike">
+
+## Reasons you might dislike Proton as a company (even though we still recommend their services)
+
+There is debate among activists about whether it's safe for us to use services from [Proton](https://proton.me/). Proton's services are gaining a lot of adoption right now, which we think is a good thing because they enable safe emailing and doc/spreadsheet collaboration. But there are security caveats to the software as well as a number of reasonable concerns about the company that cause some activists to stay away from it.
+
+We often get asked why we recommend Proton, so we wanted to offer a full explanation of what it protects, what it does not protect, how to ensure you are using it safely, and why we recommend it even though the company sometimes does shitty things. And in case we haven't convinced you, we also offer a list of other secure options.
+
+### 1. Their CEO praised the Republican party and a Trump appointee
+
+In January 2025, Proton's CEO [praised the Republican Party and a Trump appointee](https://theintercept.com/2025/01/28/proton-mail-andy-yen-trump-republicans/). Some interpreted this as a sign that Proton was aligning themselves with authoritarian forces and that our data was no longer safe there. We take a different stance. We think this was a foolish misstep from a CEO who doesn't understand the political leanings of Proton's users. It was stupid and concerning, but most CEOs are terrible. If you have ethical objections to this and want to use another service, that makes sense. However, this is far from enough evidence to claim that the service itself is now no longer secure.
+
+### 2. They cooperate with court orders where Swiss law requires it
+
+When we hear about a company like Proton being compelled to give data to the FBI about activists, it's understandable to think that they are no longer trustworthy.
+
+But as we mentioned above: this is true of every single provider out there. Unless they are willing to [shut down to avoid a court order](https://www.theguardian.com/commentisfree/2014/may/20/why-did-lavabit-shut-down-snowden-email), every single one of them will eventually cooperate with the cops.
+
+Some movement-aligned providers might use legal means to push back more to reduce the scope of the subpoena, which makes them worth considering. (See [alternatives](#alternatives) below.)
+
+A more important question is whether a provider will collaborate with the cops *without* receiving a court order. For example, Ring sometimes gives over data when the cops simply ask for it, even without a court order. Proton has [one public case](https://theintercept.com/2025/09/12/proton-mail-journalist-accounts-suspended/) where they suspended an account without a court order, but later reinstated it. There are no public cases of them turning over data without a court order.
+
+You can look at the number of court orders that Proton contests and complies with on their [transparency page](https://proton.me/legal/transparency).
+
+### 3. Their marketing is overhyped and makes broad claims that mislead users into thinking they have more protection than they do
+
+Proton's marketing often makes misleading claims about the amount of privacy and security you get with their services. For example, their marketing page for Proton Mail used to state that it was "anonymous email." We've shown above how that is not true in most cases. They now say "Private email" which is more accurate.
+
+Similarly, their response to the FBI deanonymizing a Stop Cop City activist was terrible. They could have used it as an opportunity to educate users about how to use the service anonymously. Instead they got defensive and tried to [mince words](https://bsky.app/profile/bennjordan.bsky.social/post/3mgfp6gswz22g).
+
+We think that this is a really bad practice because it leads to people trusting the service in situations where they shouldn't. That's a legitimate concern and we should keep pushing Proton to do better.
+
+Overhyped marketing is dangerous to our community, but the core service is still secure and a big upgrade from using Google.
+
+All of that said, we still think Proton is a good tool for certain types of risk profiles in activist communities. We hope that someday services will emerge that align with our values even more and are easy for beginners to use.
+
+Even though we are recommending Proton, we should absolutely continue to pressure them to be accountable for their actions. We shouldn't need to write an article like this one. Many activists won't ever see this article and will only hear the advice "Proton is safer for activists" and may assume they are safer than they are.
+
+</section>
+
+<section id="other-services">
+
+## What about Proton's other services?
+
+If you're paying for Proton Ultimate (which gives you access to all of their services), you might want to use everything in their suite. That said, we think there are better options for most of their other products.
+
+* **Proton VPN:** We recommend it if you need a free option, but [Mullvad](https://mullvad.net/en) goes to greater lengths to protect your anonymity.
+* **Proton Pass:** It's fine, but [1Password](https://1password.com/) is more user-friendly and [Bitwarden](https://bitwarden.com/) has a free plan and is more powerful.
+* **Proton Calendar:** Actually a pretty good tool. However, it's hard to get an encrypted calendar to play nicely with other people's calendars.
+* **Proton Authenticator:** Also fine, better to use the authenticator built into 1Password if you use it already. If you need a standalone tool, use [Ente Auth](https://ente.com/auth/).
+* **Proton Meet:** Currently outsources to a US company, which means the US government can compel the company to turn over IP addresses of users. Better to use [Signal group video calls](https://support.signal.org/hc/en-us/articles/360052977792-Group-Calling-Voice-or-Video) or [Zoom with end-to-end encryption](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0065408) turned on. (Always use a [VPN](/essentials/#vpn).)
+
+</section>
+
+<section id="alternatives">
+
+## Proton alternatives
+
+If you decide Proton's services aren't the right fit for you or your team, there are alternatives you can consider.
+
+**Docs/Sheets/Drive**
+
+* [**Google Docs**](https://workspace.google.com/products/docs/): Even with all the risks of using Google, we think it's actually a fine choice in some situations. If you aren't concerned with the cops having easier access to your data or the corporate surveillance that Google is always doing, it might be a fine choice for your email/docs.
+* [**CryptPad**](https://cryptpad.fr/): Commonly used for document collaboration. If you need an encrypted alternative to Google Forms, CryptPad forms are a pretty good option.
+* [**Next Cloud Office**](https://nextcloud.com/office/): Requires technical skills to deploy and manage your own hosted version of the software. The interface is less user-friendly, but you're in full control of the data. For this it would be easiest to use a managed host (like [Cloud68](https://cloud68.co/managed-hosting/nextcloud)), or you can do it yourself (using something like [Coop Cloud](https://coopcloud.tech/)).
+
+**Email**
+
+* [**Signal**](https://signal.org/): Don't use email for **sensitive** communications. Use [Signal](/signal/).
+* [**RiseUp.net**](https://riseup.net/): Movement-aligned email provider. Requires an invite code from an existing member, though, which makes it hard to access for many folks. They offer "zero knowledge" encryption in a similar way Proton does. Here is an [interview](https://pramen.io/en/2020/06/interview-with-riseup-tech-collective/) they did about the risk of receiving a wiretap.
+* [**Tuta**](https://tuta.com/): End-to-end encrypted email. Unlike Proton, the encryption doesn't work with other email providers. It only works when emailing other Tuta users, which makes it quite a bit less effective. Similar to Proton, it has a "password protected" email feature when emailing external users.
+
+</section>
+
+<section id="learn-more">
+
+## Learn more
+
+* [Proton's analysis of Swiss privacy laws](https://proton.me/blog/switzerland)
+* [Proton's "zero-access" encryption (emails with non-Proton users)](https://proton.me/learn/encryption/types-of-encryption/zero-access)
+* [Proton's "information for law enforcement" page](https://proton.me/legal/law-enforcement)
+* [Proton's transparency report](https://proton.me/legal/transparency)
+* Freedom of the Press Foundation: [Proton Mail is not for anonymity](https://freedom.press/digisec/blog/proton-mail-is-not-for-anonymity/) and [Proton Mail user guide](https://freedom.press/digisec/blog/protonmail-pro/)
+* [Webinar](https://mayfirst.coop/en/audio/can-the-feds-get-my-data/) from May First about whether your data is safe overseas. They're a movement-aligned hosting provider that provides hosting to RiseUp.net email. Includes FBI subpoenas they received and a video clip of the FBI seizing one of their servers. We don't agree with the conclusions they draw on the webinar about hosting overseas actually being more risky because it would require overseas legal representation, but we wanted to link it here as part of the conversation. (You can just find legal representation in the country/jurisdiction in question.)
+
+</section>

--- a/lib/mdx-options.js
+++ b/lib/mdx-options.js
@@ -69,7 +69,7 @@ const ALLOWED_HTML_ELEMENTS = new Set([
   'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'span',
   'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'th', 'thead', 'tr',
   'u', 'ul', 'del', 'ins', 'mark', 'small', 'details', 'summary',
-  'figure', 'figcaption', 'video', 'source',
+  'figure', 'figcaption', 'video', 'source', 'section',
 ]);
 
 // Event handler attribute pattern

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -60,7 +60,7 @@ const ALLOWED_HTML_ELEMENTS = new Set([
   'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'span',
   'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'th', 'thead', 'tr',
   'u', 'ul', 'del', 'ins', 'mark', 'small', 'details', 'summary',
-  'figure', 'figcaption', 'video', 'source',
+  'figure', 'figcaption', 'video', 'source', 'section',
 ]);
 
 // ─── Remark plugins for AST validation ───────────────────────────


### PR DESCRIPTION
Replaces the short "Can we trust Proton?" page with a longer guide
covering what is and isn't encrypted, common misunderstandings, and
when to use other tools. Each H2 is wrapped in a <section> element.

Adds parenthetical pointers to the new page from places that actively
recommend Proton (email, planning-checklist, emergency-contacts,
secondary, share-media), and softens the existing defensive framing
in vpn and proton-docs-mail to focus on safe use instead of CEO
concerns.

Adds <section> to the MDX allowed-elements list in lib/mdx-options.js
and scripts/validate-content.mjs.
