### PR TITLE
Make WhatsApp "sensitive conversation" advice less alarming and more clear

### DIFF
--- a/content/en/checklist-items/whatsapp-no-sensitive-topics.mdx
+++ b/content/en/checklist-items/whatsapp-no-sensitive-topics.mdx
@@ -1,15 +1,17 @@
 ---
-title: Don't discuss highly sensitive political topics on WhatsApp
+title: Don't share anything on WhatsApp that you wouldn't also post on social media
 preview: |
-  Move high-risk conversations (ICE watch, direct actions, election defense) to Signal or in-person.
+  WhatsApp is good for moblizing large numbers of people, but not good for higher-risk planning
 do: |
-  Use WhatsApp for less politically targeted work (canvassing, broad outreach)
+  Use WhatsApp for mass mobilizing (in a similar way that you'd use social media)
 dont: |
   Plan ICE watch shifts, election defense, or direct actions on WhatsApp
 titleBadges: []
 firstPublished: 2026-05-22
 lastUpdated: 2026-05-22
 ---
-If you're going to use WhatsApp for activism, it's best used for work that is less politically targeted, like election canvassing or neighborhood organizing. 
+Be aware that discussions around political or strategic topics may be monitored by far-right actors, especially in groups or channels used for mass communication/mobilization where you don't fully control who joins. 
 
-You should always assume that large groups (whether on Signal or WhatsApp or anywhere else) have bad actors in it. You should only talk about truly sensitive topics with trusted folks (via Signal or in-person).
+Avoid saying anything on WhatsApp that you wouldn't publish openly on social media.
+
+If you're planning sensitive actions among trusted folks, use [Signal](/signal/).

--- a/content/en/checklist-items/whatsapp-no-sensitive-topics.mdx
+++ b/content/en/checklist-items/whatsapp-no-sensitive-topics.mdx
@@ -1,7 +1,7 @@
 ---
 title: Don't share anything on WhatsApp that you wouldn't also post on social media
 preview: |
-  WhatsApp is good for moblizing large numbers of people, but not good for higher-risk planning
+  WhatsApp is good for mobilizing large numbers of people, but not good for higher-risk planning
 do: |
   Use WhatsApp for mass mobilizing (in a similar way that you'd use social media)
 dont: |

--- a/content/en/guides/whatsapp.mdx
+++ b/content/en/guides/whatsapp.mdx
@@ -23,18 +23,17 @@ A lot of activism is already happening on WhatsApp, especially in immigrant comm
 
 Your WhatsApp messages are end-to-end encrypted, which makes WhatsApp more secure than regular text messages for protecting what you say. If the cops subpoena your phone carrier for your regular texts, they can see the content of every message. If they subpoena Meta for your WhatsApp messages, they cannot see the content (as long as you don't have Chat Backups enabled).
 
-For sensitive political organizing, [Signal](/signal/) is usually a better choice to protect you from government surveillance. But if you're organizing with a community that is already on WhatsApp and is unlikely to switch platforms, the guide below will help keep your messages safer.
+<Alert type="warning">**Think of doing large group organizing WhatsApp the same way you would social media:** Assume that bad actors (government, right-wing) could join any large-unvetted group just like they could see your social media feed. Assume they can also see who is int he group in the same way they could see who is following you on social media. Just like social media, WhatsApp can help to do mass mobilizations, but for sensitive planning, [Signal](/signal) is usual a more secure choice.</Alert>
 
-<Alert type="warning">
-  Even with the protections in this guide, there are a number of things WhatsApp will always be able to turn over to law enforcement:
+Even with the protections in this guide, there are a number of things WhatsApp will always be able to turn over to law enforcement:
 
-  * Your entire contact list (if you have ever given the app access to your contact list, they will always have it, even if you disable it later)
-  * The names and members of all the groups you're in
-  * Which phone numbers you're messaging and when (they can even get this information in [real-time](https://www.rollingstone.com/politics/politics-features/whatsapp-imessage-facebook-apple-fbi-privacy-1261816/), which most other tech companies don't provide to law enforcement)
-  * All the other WhatsApp users who have YOU in their contact list ([source](https://www.justsecurity.org/79549/we-now-know-what-information-the-fbi-can-obtain-from-encrypted-messaging-apps/))
-  * Any IP addresses you've used to connect to the app (which usually indicates your city-level location)
-  * If you enable chat backups, Google or Apple can be compelled to turn them over, and they contain all of your messages. You can mitigate this in two separate ways: by turning on WhatsApp's built-in end-to-end encrypted backup option (available on both Android and iPhone), and on iPhone, by additionally turning on Apple's Advanced Data Protection for iCloud (an extra iCloud-wide setting, iPhone only).
-</Alert>
+* Your entire contact list (if you have ever given the app access to your contact list, they will always have it, even if you disable it later)
+* The names and members of all the groups you're in
+* Which phone numbers you're messaging and when (they can even get this information in [real-time](https://www.rollingstone.com/politics/politics-features/whatsapp-imessage-facebook-apple-fbi-privacy-1261816/), which most other tech companies don't provide to law enforcement)
+* All the other WhatsApp users who have YOU in their contact list ([source](https://www.justsecurity.org/79549/we-now-know-what-information-the-fbi-can-obtain-from-encrypted-messaging-apps/))
+* Any IP addresses you've used to connect to the app (which usually indicates your city-level location)
+* If you enable chat backups, Google or Apple can be compelled to turn them over, and they contain all of your messages. You can mitigate this in two separate ways: by turning on WhatsApp's built-in end-to-end encrypted backup option (available on both Android and iPhone), and on iPhone, by additionally turning on Apple's Advanced Data Protection for iCloud (an extra iCloud-wide setting, iPhone only).
+
 
 **Brand new to WhatsApp?** See this guide on [how to use WhatsApp](https://ssd.eff.org/module/how-to-use-whatsapp).
 
@@ -62,9 +61,9 @@ For sensitive political organizing, [Signal](/signal/) is usually a better choic
   </RiskLevel>
 
   <ChecklistItemGroup>
-    <ChecklistItem slug="whatsapp-meta-ai" />
-
     <ChecklistItem slug="whatsapp-no-sensitive-topics" />
+
+    <ChecklistItem slug="whatsapp-meta-ai" />
 
     <ChecklistItem slug="whatsapp-pairing-code-scams" />
 

--- a/content/en/guides/whatsapp.mdx
+++ b/content/en/guides/whatsapp.mdx
@@ -23,7 +23,7 @@ A lot of activism is already happening on WhatsApp, especially in immigrant comm
 
 Your WhatsApp messages are end-to-end encrypted, which makes WhatsApp more secure than regular text messages for protecting what you say. If the cops subpoena your phone carrier for your regular texts, they can see the content of every message. If they subpoena Meta for your WhatsApp messages, they cannot see the content (as long as you don't have Chat Backups enabled).
 
-<Alert type="warning">**Think of doing large group organizing WhatsApp the same way you would social media:** Assume that bad actors (government, right-wing) could join any large-unvetted group just like they could see your social media feed. Assume they can also see who is int he group in the same way they could see who is following you on social media. Just like social media, WhatsApp can help to do mass mobilizations, but for sensitive planning, [Signal](/signal) is usual a more secure choice.</Alert>
+<Alert type="warning">**Think of doing large group organizing WhatsApp the same way you would social media:** Assume that bad actors (government, right-wing) could join any large-unvetted group just like they could see your social media feed. Assume they can also see who is int he group in the same way they could see who is following you on social media. Just like social media, WhatsApp can help to do mass mobilizations, but for sensitive planning, [Signal](/signal/) is usual a more secure choice.</Alert>
 
 Even with the protections in this guide, there are a number of things WhatsApp will always be able to turn over to law enforcement:
 

--- a/content/en/guides/whatsapp.mdx
+++ b/content/en/guides/whatsapp.mdx
@@ -17,7 +17,7 @@ relatedGuides:
   - spyware
   - doxxing
 firstPublished: 2026-05-22
-lastUpdated: 2026-05-22
+lastUpdated: 2026-05-26
 ---
 A lot of activism is already happening on WhatsApp, especially in immigrant communities. It isn't the most secure or private choice, but it's sometimes a useful tool for community organizing because people are already using it.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote WhatsApp guidance to advise avoiding anything you wouldn’t post publicly; updated do/don’t recommendations.
  * Clarified risks from monitoring in mass-communication groups and recommended using WhatsApp only for mass mobilization.
  * Recommended using Signal or other trusted channels for sensitive planning and coordination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ActivistChecklist/ActivistChecklist/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->