### PR TITLE
fix: add favicon link tags to <head> (#490)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,15 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  icons: {
+    icon: [
+      { url: '/favicon.ico' },
+      { url: '/favicon-16x16.png', sizes: '16x16', type: 'image/png' },
+      { url: '/favicon-32x32.png', sizes: '32x32', type: 'image/png' },
+    ],
+  },
+};
+
 export default function RootLayout({ children }) {
   return children;
 }


### PR DESCRIPTION
Hello! The favicon files existed in `/public` but were never declared in the `<head>`. Added explicit metadata to `app/layout.tsx` so Next.js injects the `<link rel="icon">` tags into the HTML head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added favicon and icon metadata configuration for improved app branding across browsers and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->