### PR TITLE
Adding news: Federal agents track down Syracuse woman, demand she remove Instagram post about ICE

### DIFF
--- a/content/en/news/federal-agents-track-down-syracuse-woman-demand-she-remove-instagram-post-about-ice.mdx
+++ b/content/en/news/federal-agents-track-down-syracuse-woman-demand-she-remove-instagram-post-about-ice.mdx
@@ -1,0 +1,13 @@
+---
+title: >-
+  Federal agents track down Syracuse woman, demand she remove Instagram post
+  about ICE
+date: 2026-06-24
+url: >-
+  https://www.syracuse.com/news/2026/06/federal-agents-track-down-syracuse-woman-demand-she-remove-instagram-post-about-ice.html
+source: syracuse
+firstPublished: 2026-06-25
+lastUpdated: 2026-06-25
+tags: 'ice, state repression'
+---
+


### PR DESCRIPTION
Add news item.

Article: https://www.syracuse.com/news/2026/06/federal-agents-track-down-syracuse-woman-demand-she-remove-instagram-post-about-ice.html
