### PR TITLE
Add link on ICE guide to crimethinc article of bay area zine

### DIFF
--- a/content/en/guides/ice.mdx
+++ b/content/en/guides/ice.mdx
@@ -46,6 +46,8 @@ lastUpdated: 2026-02-02
   If you only have 15–20 minutes, start with these items.
 
   <ChecklistItemGroup>
+    <ChecklistItem slug="ad-id" />
+
     <ChecklistItem slug="signal" />
 
     <ChecklistItem slug="signal-disappearing" />
@@ -104,8 +106,6 @@ lastUpdated: 2026-02-02
     <ChecklistItem slug="clearview" />
 
     <ChecklistItem slug="vpn" />
-
-    <ChecklistItem slug="ad-id" />
   </ChecklistItemGroup>
 </Section>
 
@@ -151,7 +151,11 @@ lastUpdated: 2026-02-02
 </Section>
 
 <Section title="Other resources" slug="resources">
-  * **Starting rapid response and foot patrol:** [Minneapolis guides](https://defend612.com/local-resources/), [Minneapolis lessons](https://crimethinc.com/2026/01/15/rapid-response-networks-in-the-twin-cities-a-guide-to-an-updated-model), [Charlotte toolkit](https://docs.google.com/document/d/14xX5K4exAvFLx9nW-SVCaKP5RDM6y4WveLflBFYS7To/edit?tab=t.0) (Google docs link)
+  * **Starting rapid response or foot patrol group:** 
+    * [Bay Area rapid response guide](https://crimethinc.com/2026/07/16/protecting-your-neighbors-by-following-ice-vehicles-a-guide-from-the-bay-area) and [zine](https://cdn.crimethinc.com/assets/articles/2026/07/16/move-ice-get-out-the-bay_print_black_and_white.pdf)
+    * [Minneapolis guides](https://defend612.com/local-resources/)
+    * [Minneapolis lessons](https://crimethinc.com/2026/01/15/rapid-response-networks-in-the-twin-cities-a-guide-to-an-updated-model)
+    * [Charlotte toolkit](https://docs.google.com/document/d/14xX5K4exAvFLx9nW-SVCaKP5RDM6y4WveLflBFYS7To/edit?tab=t.0) (Google docs link)
   * **Safety:**
     * [Risk assessments and community safety toolkits from Vision Change Win](https://visionchangewin.org/services-and-programs/community-safety/)
     * [Safety resources from Kala Mendoza](https://linktr.ee/kalamendoza)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ICE Watch digital security checklist by adding ad-id guidance for all observers and removing it from the frequent-observer section.
  * Expanded the “Other resources” section with Bay Area rapid response resources, while retaining Minneapolis and Charlotte materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->