### PR TITLE
Fix end of life update script

### DIFF
--- a/.rsync-exclude
+++ b/.rsync-exclude
@@ -35,6 +35,12 @@ webhooks/webhook-secrets.local.php
 # Same rule as webhooks: excluded paths are not deleted by rsync --delete.
 large-assets/***
 
+# EOL snapshot is server-owned: the daily cron and the build's prebuild step both
+# write it straight to the docroot via EOL_SNAPSHOT_PATH (.env.production). The
+# copy inside out/ comes from the repo's public/data/ and is stale, so without
+# this exclude every deploy would overwrite the fresh docroot copy with it.
+data/eol-snapshot.json
+
 # Build / dev artifacts
 out
 .next


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Preserved the server-managed end-of-life snapshot during deployments, preventing it from being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->