### PR TITLE
Fix canary healthcheck cron and rename script

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -142,6 +142,11 @@ DOMAIN_NAME=activistchecklist.org
 DOMAIN_WARN_DAYS=45
 DOMAIN_HEALTHCHECK_PING_URL=https://hc-ping.com/your-domain-check-uuid
 
+# === scripts/healthcheck-canary.mjs (warrant canary freshness)
+# Pings on success, suffixed with /fail when the canary is stale or unreadable.
+HEALTHCHECK_CANARY_URL=https://hc-ping.com/your-canary-check-uuid
+CANARY_MAX_AGE_DAYS=90
+
 # === scripts/fetch-endoflife-snapshot.mjs (powers /updates page)
 # Healthchecks.io ping URL pinged on success / suffixed with /fail on error.
 # Leave empty in dev — the script silently skips pings.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "healthcheck-ssl": "bash scripts/healthcheck-ssl.sh",
     "healthcheck-domain": "bash scripts/healthcheck-domain.sh",
     "healthcheck-api": "bash scripts/healthcheck-api.sh",
+    "healthcheck-canary": "node --env-file-if-exists=.env --env-file-if-exists=.env.production scripts/healthcheck-canary.mjs",
     "check-build": "node scripts/check-build.mjs",
     "validate-build": "node scripts/validate-build.mjs",
     "canary": "node scripts/canary.mjs",

--- a/public/files/canary.txt
+++ b/public/files/canary.txt
@@ -1,26 +1,26 @@
 -----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA256
 
-ActivistChecklist.org Warrant Canary · 2026-06-22 16:02:50 UTC
+ActivistChecklist.org Warrant Canary · 2026-08-11 18:42:49 UTC
 
-As of June 22, 2026, ActivistChecklist.org:
+As of August 11, 2026, ActivistChecklist.org:
 
 * has not been compelled to alter the site or its behavior for surveillance purposes
 * has not been served with any legal demand for user data accompanied by a gag order
 * retains sole control over its infrastructure and signing keys
 
-This canary is valid through September 30, 2026. After that date, the absence of a newer
+This canary is valid through November 19, 2026. After that date, the absence of a newer
 indicates either a missed update or compromise.
 
 Datestamp Proof:
-  News headline: Trump official vows to prosecute ‘vandalizing’ of reflecting pool after five people reportedly arrested – live
-  News URL:      https://www.theguardian.com/us-news/live/2026/jun/22/trump-reflecting-pool-vandalized-lincoln-memorial-iran-us-politics-latest-news-updates
-  XMR block:     #3701963, 2026-06-22 16:01:54 UTC
-  Block hash:    798adcf3448e8642482d3bf4dd6ab4e122db287f021ce7a06ec9a97722d6274a
+  News headline: The Guardian view on AI money in US politics: not the way to hold an urgent democratic debate | Editorial
+  News URL:      https://www.theguardian.com/commentisfree/2026/aug/11/the-guardian-view-on-ai-money-in-us-politics-not-the-way-to-hold-an-urgent-democratic-debate
+  XMR block:     #3738017, 2026-08-11 18:41:11 UTC
+  Block hash:    ccd5b1386c641cea8219024c2b3d23d78f2ad89cacd0fa8fdc179d9cad33d1ba
 -----BEGIN PGP SIGNATURE-----
 
-iHUEARYIAB0WIQS3qluewPA1HZ+344fQN7sOiHIG7AUCajlctwAKCRDQN7sOiHIG
-7JxgAQDB1GNPjSrrNIPckAg2K7OlQOA2R7X6vLTP+hOSedCY8AD/Uw9U7ybBw5sV
-Ms5WRPGP3vCj9VeKO1WYe9CQ1wy1RQk=
-=XmG/
+iHUEARYIAB0WIQS3qluewPA1HZ+344fQN7sOiHIG7AUCanttVwAKCRDQN7sOiHIG
+7KUuAQCF1wJnTSqE4xO+A4H2UnVkugmanzwzy9XK43i77V/e9gEAzs2p/2NtGw2o
+nrQm7IAZ6FZx8sYQeScAkS7WQsAA1A4=
+=AJZe
 -----END PGP SIGNATURE-----

--- a/scripts/healthcheck-canary.mjs
+++ b/scripts/healthcheck-canary.mjs
@@ -7,10 +7,15 @@
  *
  * Env vars:
  *   HEALTHCHECK_CANARY_URL  required, the base ping URL from healthchecks.io
- *   CANARY_MAX_AGE_DAYS      optional, defaults to 90
+ *   CANARY_MAX_AGE_DAYS     optional, defaults to 90
  *
- * Example cron (run every Monday at 14:00 UTC):
- *   0 14 * * 1 cd /path/to/repo && HEALTHCHECK_CANARY_URL=https://hc-ping.com/xxx node scripts/canary-healthcheck.mjs >> /var/log/canary-healthcheck.log 2>&1
+ * Usage:
+ *   pnpm healthcheck-canary
+ *
+ * Example cron (run every Monday at 14:00 UTC). The two --env-file-if-exists
+ * flags mean the same line works on the server (.env.production) and in dev
+ * (.env), and cron does not need nvm/pnpm on PATH:
+ *   0 14 * * 1 cd /path/to/repo && /path/to/node --env-file-if-exists=.env --env-file-if-exists=.env.production scripts/healthcheck-canary.mjs >> /path/to/logs/healthcheck-canary.log 2>&1
  */
 
 import { readFile } from 'node:fs/promises';


### PR DESCRIPTION
The Monday cron ran node with --env-file=.env, but the server only has
.env.production, so every run died with ".env: not found" and the check
never pinged. HEALTHCHECK_CANARY_URL was also missing from the production
env file.

- Rename scripts/canary-healthcheck.mjs to scripts/healthcheck-canary.mjs
  so it matches the other healthcheck-* scripts
- Add a healthcheck-canary package script that loads .env and
  .env.production via --env-file-if-exists, so the same command works in
  dev and on the server
- Document HEALTHCHECK_CANARY_URL and CANARY_MAX_AGE_DAYS in .env.template
