### PR TITLE
Add onion healthcheck cron

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -151,3 +151,17 @@ CANARY_MAX_AGE_DAYS=90
 # Healthchecks.io ping URL pinged on success / suffixed with /fail on error.
 # Leave empty in dev — the script silently skips pings.
 HEALTHCHECK_EOL_PING_URL=https://hc-ping.com/your-eol-check-uuid
+
+# === scripts/healthcheck-onion.sh (Tor onion service reachability)
+# Requires a local Tor SOCKS proxy (the `tor` daemon) on the machine running the check.
+# In production this runs on a GitHub runner (.github/workflows/healthcheck-onion.yml),
+# which reads the ping URL from the repository secret ONION_HEALTHCHECK_PING_URL —
+# the var below is only for running the check by hand on a machine with tor.
+ONION_HEALTHCHECK_PING_URL=https://hc-ping.com/your-onion-check-uuid
+# Optional: defaults to the address published in content/en/pages/onion.mdx
+# ONION_ADDRESS=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion
+# TOR_SOCKS_PROXY=127.0.0.1:9050
+# ONION_GUIDE_PATH=/essentials/
+# ONION_HEALTH_ATTEMPTS=3
+# ONION_HEALTH_RETRY_SLEEP=5
+# ONION_HEALTH_TIMEOUT=60

--- a/.github/workflows/healthcheck-onion.yml
+++ b/.github/workflows/healthcheck-onion.yml
@@ -1,0 +1,74 @@
+# Checks that our Tor onion service is reachable and serving the real site.
+#
+# The shared web host can't run a Tor daemon, so this runs on a GitHub runner
+# instead: install tor, wait for it to bootstrap, then run the same
+# scripts/healthcheck-onion.sh that would run from cron elsewhere. The script
+# pings Healthchecks.io itself (success, or /fail with diagnostics).
+#
+# Required repository secret:
+#   ONION_HEALTHCHECK_PING_URL — the Ping URL of the onion check on Healthchecks.io
+#
+# Scheduled runs only happen on the default branch, and GitHub delays cron runs
+# under load, so give the Healthchecks check a generous grace period (period 1h,
+# grace 1h works well with the 30-minute schedule below).
+
+name: Onion healthcheck
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: healthcheck-onion
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Tor
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tor
+          sudo systemctl start tor@default || sudo service tor start
+
+      # Gate on a third-party onion we don't control. If this fails, the runner's
+      # Tor is broken (or Tor itself is having a bad day) and any failure from our
+      # own check would be noise — so we stop here without pinging Healthchecks.
+      # The job goes red and GitHub emails you; the check goes late instead of down.
+      - name: Wait for Tor to bootstrap
+        env:
+          # torproject.org's own onion service, used purely as a liveness control.
+          CONTROL_ONION: http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion/
+        run: |
+          for attempt in $(seq 1 8); do
+            if curl -fsS --max-time 45 --socks5-hostname 127.0.0.1:9050 \
+              -o /dev/null "$CONTROL_ONION"; then
+              echo "Tor is up and resolving onion services (attempt $attempt)."
+              exit 0
+            fi
+            echo "Tor not ready yet (attempt $attempt/8); waiting 15s..."
+            sleep 15
+          done
+          echo "::error::Tor never reached a usable state on this runner. Skipping the onion check so we don't report a false outage."
+          exit 1
+
+      - name: Check onion service
+        env:
+          ONION_HEALTHCHECK_PING_URL: ${{ secrets.ONION_HEALTHCHECK_PING_URL }}
+          TOR_SOCKS_PROXY: 127.0.0.1:9050
+        run: |
+          if [ -z "$ONION_HEALTHCHECK_PING_URL" ]; then
+            echo "::error::Repository secret ONION_HEALTHCHECK_PING_URL is not set."
+            exit 1
+          fi
+          bash scripts/healthcheck-onion.sh

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "healthcheck-ssl": "bash scripts/healthcheck-ssl.sh",
     "healthcheck-domain": "bash scripts/healthcheck-domain.sh",
     "healthcheck-api": "bash scripts/healthcheck-api.sh",
+    "healthcheck-onion": "bash scripts/healthcheck-onion.sh",
     "healthcheck-canary": "node --env-file-if-exists=.env --env-file-if-exists=.env.production scripts/healthcheck-canary.mjs",
     "check-build": "node scripts/check-build.mjs",
     "validate-build": "node scripts/validate-build.mjs",

--- a/scripts/healthcheck-onion.sh
+++ b/scripts/healthcheck-onion.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Tor onion service health check with Healthchecks.io ping.
+#
+# Checks, in order:
+#   1. The .onion address published in content/en/pages/onion.mdx parses and looks valid.
+#   2. That address matches the PGP-signed copy in public/files/onion-address.txt.asc
+#      (catches an edited/tampered address in the page before readers hit it).
+#   3. The onion service answers over Tor and serves the real site.
+#
+# Requires a local Tor SOCKS proxy (the `tor` daemon, default 127.0.0.1:9050).
+# Onion fetches are slow, so timeouts are generous and failures are retried.
+#
+# In production this runs on a GitHub runner every 30 minutes, since the web host
+# has no Tor daemon: see .github/workflows/healthcheck-onion.yml. The cron form
+# below works on any machine that does run tor.
+#
+# Setup example:
+#   export ONION_HEALTHCHECK_PING_URL="https://hc-ping.com/your-uuid"
+#   */30 * * * * /absolute/path/to/repo/scripts/healthcheck-onion.sh >/dev/null 2>&1
+#
+# Optional env vars:
+#   ONION_ADDRESS — override the address instead of reading onion.mdx
+#   TOR_SOCKS_PROXY=127.0.0.1:9050
+#   ONION_GUIDE_PATH=/essentials/
+#   ONION_HEALTH_ATTEMPTS — fetch retries per URL (default: 3)
+#   ONION_HEALTH_RETRY_SLEEP — seconds between retries (default: 5)
+#   ONION_HEALTH_TIMEOUT — seconds per fetch (default: 60)
+#   LOG_DIR / LOG_LINES_KEEP — shared log settings (see scripts/log.sh)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "healthcheck-onion.log" "$(resolve_server_log_lines_keep)"
+
+ONION_MDX="$PROJECT_DIR/content/en/pages/onion.mdx"
+ONION_SIGNED_FILE="$PROJECT_DIR/public/files/onion-address.txt.asc"
+TOR_SOCKS_PROXY="${TOR_SOCKS_PROXY:-127.0.0.1:9050}"
+GUIDE_PATH="${ONION_GUIDE_PATH:-/essentials/}"
+HC_PING_URL="${ONION_HEALTHCHECK_PING_URL:-}"
+ATTEMPTS="${ONION_HEALTH_ATTEMPTS:-3}"
+RETRY_SLEEP="${ONION_HEALTH_RETRY_SLEEP:-5}"
+FETCH_TIMEOUT="${ONION_HEALTH_TIMEOUT:-60}"
+if [[ "${ATTEMPTS:-0}" -lt 1 ]]; then ATTEMPTS=1; fi
+
+# v3 onion addresses are 56 base32 chars (a-z, 2-7) plus ".onion".
+ONION_RE='[a-z2-7]{56}\.onion'
+
+if [[ -z "$HC_PING_URL" ]]; then
+  msg="ONION_HEALTHCHECK_PING_URL is required"
+  echo "$msg" >&2
+  log "$msg"
+  exit 1
+fi
+
+hc_post() {
+  local url="$1"
+  local body="$2"
+  curl -fsS --max-time 10 --retry 3 --data-raw "$body" "$url" >/dev/null || true
+}
+
+fail() {
+  local msg="$1"
+  echo "$msg" >&2
+  scripts_log_file_failure_block "healthcheck-onion FAILED" "$msg"
+  hc_post "${HC_PING_URL%/}/fail" "$msg"
+  trim_log
+  exit 1
+}
+
+# --- 1. Resolve the address ---------------------------------------------------
+
+address="${ONION_ADDRESS:-}"
+address_source="env"
+if [[ -z "$address" ]]; then
+  address_source="onion.mdx"
+  if [[ ! -r "$ONION_MDX" ]]; then
+    fail "healthcheck-onion failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ")) reason=onion_mdx_unreadable path=$ONION_MDX"
+  fi
+  address="$(grep -oE "$ONION_RE" "$ONION_MDX" | head -1 || true)"
+fi
+# Accept a full URL in ONION_ADDRESS too; we only want the host.
+address="$(echo "$address" | grep -oE "$ONION_RE" | head -1 || true)"
+
+if [[ -z "$address" ]]; then
+  fail "healthcheck-onion failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ")) reason=no_valid_onion_address source=$address_source"
+fi
+
+log_echo "=== healthcheck-onion started (log: $LOG_FILE) address=$address source=$address_source proxy=$TOR_SOCKS_PROXY ==="
+
+# --- 2. Compare against the PGP-signed copy -----------------------------------
+
+if [[ ! -r "$ONION_SIGNED_FILE" ]]; then
+  fail "healthcheck-onion failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ")) reason=signed_address_file_unreadable file=$ONION_SIGNED_FILE"
+fi
+
+signed_address="$(grep -oE "$ONION_RE" "$ONION_SIGNED_FILE" | head -1 || true)"
+if [[ -z "$signed_address" ]]; then
+  fail "healthcheck-onion failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ")) reason=signed_address_not_found file=$ONION_SIGNED_FILE"
+fi
+
+if [[ "$signed_address" != "$address" ]]; then
+  fail "$(
+    printf "healthcheck-onion failed (%s)\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    printf "reason=address_mismatch published=%s signed=%s\n" "$address" "$signed_address"
+    printf "The published address does not match the PGP-signed copy. Treat as tampering until proven otherwise.\n"
+  )"
+fi
+
+# --- 3. Fetch over Tor --------------------------------------------------------
+
+errors=()
+
+# Fetches a path over the Tor SOCKS proxy, retrying transient circuit failures.
+# $1 = path, $2 = optional string that must appear in the body.
+check_path() {
+  local path="$1"
+  local expect="${2:-}"
+  local url="http://$address$path"
+  local diag=()
+  local a tmp cerr meta curl_exit http_code time_total bytes snippet title
+
+  for ((a = 1; a <= ATTEMPTS; a++)); do
+    tmp=$(mktemp)
+    cerr=$(mktemp)
+    set +e
+    meta=$(curl -sS --max-time "$FETCH_TIMEOUT" --socks5-hostname "$TOR_SOCKS_PROXY" \
+      -o "$tmp" -w "%{http_code}|%{time_total}" "$url" 2>"$cerr")
+    curl_exit=$?
+    set -e
+    IFS='|' read -r http_code time_total <<<"$meta"
+    bytes=$(wc -c <"$tmp" | tr -d ' ')
+
+    if [[ "$curl_exit" != "0" ]]; then
+      local curl_err_text="" hint="" socks_code=""
+      [[ -s "$cerr" ]] && curl_err_text=$(tr '\n' ' ' <"$cerr")
+      case "$curl_exit" in
+        5 | 7)
+          # Nothing answering on the SOCKS port: the tor daemon, not the service.
+          hint=" hint=tor_socks_proxy_unreachable_check_tor_daemon"
+          ;;
+        97)
+          # Tor reports why the SOCKS connect failed as a trailing "(NNN)" code.
+          socks_code=$(echo "$curl_err_text" | grep -oE '\(2[0-9]{2}\) *$' | tr -dc '0-9')
+          case "$socks_code" in
+            240) hint=" hint=onion_descriptor_not_found_service_likely_offline" ;;
+            241) hint=" hint=onion_descriptor_invalid" ;;
+            242) hint=" hint=onion_introduction_failed" ;;
+            243) hint=" hint=onion_rendezvous_failed" ;;
+            244) hint=" hint=onion_missing_client_auth" ;;
+            245) hint=" hint=onion_wrong_client_auth" ;;
+            246) hint=" hint=onion_address_invalid" ;;
+            247) hint=" hint=onion_introduction_timed_out" ;;
+            *) hint=" hint=tor_socks_connect_failed" ;;
+          esac
+          ;;
+      esac
+      diag+=("$path: attempt $a/$ATTEMPTS curl error http=${http_code:-?} time_s=${time_total:-?} bytes=${bytes:-?} curl_exit=$curl_exit${hint} curl_stderr=${curl_err_text}")
+      rm -f "$tmp" "$cerr"
+      if ((a < ATTEMPTS)); then sleep "$RETRY_SLEEP"; fi
+      continue
+    fi
+
+    if [[ "${http_code:-}" != "200" ]]; then
+      snippet=""
+      if [[ "$bytes" -gt 0 && "$bytes" -lt 8000 ]]; then
+        snippet=$(head -c 600 "$tmp" | tr '\n\r\t' ' ' | sed 's/  */ /g')
+        snippet=$(printf '%.500s' "$snippet")
+      fi
+      diag+=("$path: attempt $a/$ATTEMPTS non-200 response http=$http_code bytes=$bytes time_s=$time_total snippet=${snippet:-"(large or empty)"}")
+      rm -f "$tmp" "$cerr"
+      if ((a < ATTEMPTS)); then sleep "$RETRY_SLEEP"; fi
+      continue
+    fi
+
+    if [[ -z "$expect" ]] || grep -qi "$expect" "$tmp"; then
+      rm -f "$tmp" "$cerr"
+      log "$path: ok http=200 bytes=$bytes time_s=$time_total"
+      return 0
+    fi
+
+    title=$(grep -oiE '<title[^>]*>[^<]+</title>' "$tmp" | head -1 | tr '\n' ' ' || true)
+    snippet=$(head -c 800 "$tmp" | tr '\n\r\t' ' ' | sed 's/  */ /g')
+    snippet=$(printf '%.500s' "$snippet")
+    diag+=("$path: attempt $a/$ATTEMPTS HTTP 200 but grep missed \"$expect\" bytes=$bytes time_s=$time_total title=${title:-"(none)"}")
+    diag+=("$path: attempt $a/$ATTEMPTS body_snippet=$snippet")
+    rm -f "$tmp" "$cerr"
+    if ((a < ATTEMPTS)); then sleep "$RETRY_SLEEP"; fi
+  done
+
+  errors+=("$path: failed after $ATTEMPTS attempt(s) via $url")
+  errors+=("${diag[@]}")
+  return 0
+}
+
+# Homepage must load and be our site, not a parking page or the wrong service.
+check_path "/" "Activist Checklist"
+# A stable guide page confirms routing beyond the index.
+check_path "$GUIDE_PATH"
+
+if ((${#errors[@]} > 0)); then
+  body=$(
+    printf "healthcheck-onion failed (%s)\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    printf "address=%s source=%s proxy=%s guide_path=%s\n" "$address" "$address_source" "$TOR_SOCKS_PROXY" "$GUIDE_PATH"
+    printf "%s\n" "${errors[@]}"
+  )
+  fail "$body"
+fi
+
+ok_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+log_echo "healthcheck-onion ok $ok_ts address=$address"
+hc_post "${HC_PING_URL%/}" "healthcheck-onion ok $ok_ts address=$address"
+trim_log


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated monitoring for the Tor onion service, including address validation and availability checks.
  * Added configurable health-check settings for retries, timeouts, proxy access, and guide verification.
  * Added scheduled and manually triggered monitoring runs with Healthchecks.io reporting.

* **Chores**
  * Added an npm command for running the onion-service health check locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->