### PR TITLE
Add "play music" to the security party page

### DIFF
--- a/content/en/pages/party.mdx
+++ b/content/en/pages/party.mdx
@@ -36,10 +36,6 @@ We wrote this guide because we've hosted many security parties and seen how effe
 - **Security is collective.** It’s not just about your personal security. Ask yourself: “If my devices and data were in the hands of the government, is my security strong enough to keep the people in my network safe?” **We need to do this together for it to work effectively.**
 - **Safer people take bolder action.** Helping folks feel protected gives them the confidence to keep showing up.
 
-### Who can host a security party?
-
-**Anyone can host a security party.** You don't have to be a security expert. You just have to be willing to gather a few people together.
-
 ### What is a security party?
 
 A **security party** is a gathering where folks work through digital security steps together. It can be 3 people at a kitchen table or 15 people at an organizing meeting.
@@ -55,6 +51,10 @@ A **security party** is a gathering where folks work through digital security 
 - It's easier to ask a question when the person next to you is also figuring it out.
 - Most of these steps take 5 to 15 minutes once you sit down and do them. "Sit down and actually do it" is the part that rarely happens on its own.
 
+### Who can host a security party?
+
+Anyone can host a security party. **You don't have to be a security expert.** You just have to be willing to gather a few people together and work through the guides on this site.
+
 ## Design your party
 
 ### Who to invite
@@ -67,12 +67,13 @@ A **security party** is a gathering where folks work through digital security 
 ### Size, time, and place
 
 - **Size:** 3 to 15 participants is the sweet spot. For bigger gatherings, aim for about 1 tech-savvy helper for every 5 participants. For 10+, consider a “floating helper” whose only job is to check in with each person and keep things moving.
-- **Time:** 90 minutes is a good default. (Anywhere from 1 to 2 hours works, though.)
-- **Place:** Someone's home is the warmest setting. A community space, union hall, or cafe back room also works. You could even [host it at a bar](https://www.theguardian.com/us-news/2026/apr/16/big-tech-breakup-parties). Virtual works fine too.
+- **Time:** 90 minutes is a good default. (Anywhere from 1 to 3 hours can work.)
+- **Place:** Someone's home is the warmest setting. A community space, library, or union hall also works. You could even [host it at a bar](https://www.theguardian.com/us-news/2026/apr/16/big-tech-breakup-parties). Virtual works fine too.
 
 ### Ingredients for a good gathering
 
 - **Food helps:** Having snacks is more than enough. And if you have energy to host a potluck/meal, that’s great too. (If you host a meal, make sure the security work starts at a clear time otherwise the hanging out can take up the whole evening.)
+- **Music:** Since there are long periods where people are silently working, we've seen that quiet background music without lyrics can help people stay focused. (But check with your group, as this can be overstimulating/distracting for some folks.)
 - **Power:** Make sure there are extension cords and extra chargers available.
 - **Internet access:** Make sure the place you pick has fast, reliable internet access.
 - **Do something fun afterward:** Get dinner, watch a movie, hang out. It gives you something more exciting than security to look forward to.
@@ -125,7 +126,7 @@ Adjust to be shorter/longer based on your needs.
 - **[2 mins] Closing**
     - Encourage folks to think of themselves as ambassadors now. We’re most secure when most people in our organizing networks have taken these steps. Find a few opportunities this week to talk to people about what you learned.
     - (Optional) Consider starting a Signal group and having everyone set a promise for what they’ll do on their own time in the next week. Use the group to report back, celebrate progress, and ask questions.
-    - (Optional) Ask if anyone else might be interested in hosting a security party.
+    - (Optional) Ask if anyone else might be interested in hosting another security party.
 
 ### Virtual gatherings
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the party-hosting guide with clearer guidance to use the site’s available guides.
  * Expanded the recommended party duration to 1–3 hours.
  * Added libraries as potential venues and removed café back rooms.
  * Added a recommendation for quiet background music.
  * Updated the agenda to encourage hosting another security party.
  * Kept the trainer-manual resource information unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->