### PR TITLE
Disable the announcement bar

### DIFF
--- a/content/en/announcement/index.yaml
+++ b/content/en/announcement/index.yaml
@@ -1,4 +1,4 @@
-active: true
+active: false
 dismissKey: contribute-page
 title: Want to help this project?
 message: >-


### PR DESCRIPTION
Sets `active: false` on the contribute-page announcement so the bar is hidden site-wide while keeping the copy in place.