### PR TITLE
Output data file path even when we dont update

### DIFF
--- a/scripts/fetch-endoflife-snapshot.mjs
+++ b/scripts/fetch-endoflife-snapshot.mjs
@@ -445,7 +445,7 @@ async function main() {
   const newHash = stableSnapshotHash(snapshot);
   const oldHash = previous ? stableSnapshotHash(previous) : null;
   if (oldHash && newHash === oldHash) {
-    console.log(`Snapshot content unchanged (hash ${newHash.slice(0, 12)}); skipping write`);
+    console.log(`Snapshot content unchanged (hash ${newHash.slice(0, 12)}); skipping write to ${outputPath}`);
     await pingHealthcheck(true);
     return;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging when an end-of-life snapshot is unchanged by displaying the output path being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->