### PR TITLE
Fix hydration crash from relative news dates

### DIFF
--- a/__tests__/relative-date-hydration.test.js
+++ b/__tests__/relative-date-hydration.test.js
@@ -1,0 +1,96 @@
+import { formatRelativeDate, formatStableContentDate } from '../lib/utils';
+
+/**
+ * Regression: this site is a statically exported app, so server HTML is frozen
+ * at build time while the browser evaluates at page load. Rendering a
+ * time-dependent string during SSR meant an item built as "Today" hydrated the
+ * next day as "Yesterday" — React aborts hydration on that text mismatch
+ * (minified error #418), which killed every client component on the page.
+ */
+const at = (iso) => new Date(iso);
+
+describe('formatStableContentDate is independent of the clock', () => {
+  test('same input gives the same output regardless of when it is called', () => {
+    // Whatever "now" is, this function never consults it.
+    const a = formatStableContentDate('2026-08-26', 'en-US');
+    const b = formatStableContentDate('2026-08-26', 'en-US');
+    expect(a).toBe(b);
+    expect(a).toBe('Aug 26, 2026');
+  });
+
+  test('matches the >30-day form of formatRelativeDate, so old entries do not flicker', () => {
+    const old = '2025-03-05';
+    const now = at('2026-08-29T12:00:00Z');
+    expect(formatStableContentDate(old, 'en-US')).toBe(
+      formatRelativeDate(old, 'en-US', now)
+    );
+  });
+
+  test.each([null, undefined, '', 'nonsense'])('returns empty for %p', (input) => {
+    expect(formatStableContentDate(input, 'en-US')).toBe('');
+  });
+});
+
+describe('formatRelativeDate branches (clock injected)', () => {
+  const now = at('2026-08-29T12:00:00');
+
+  test.each([
+    ['2026-08-29', 'Today'],
+    ['2026-08-28', 'Yesterday'],
+    ['2026-08-26', '3 days ago'],
+    ['2026-08-22', '7 days ago'],
+  ])('%s -> %s', (date, expected) => {
+    expect(formatRelativeDate(date, 'en-US', now)).toBe(expected);
+  });
+
+  test('8 days falls out of relative wording into a calendar date', () => {
+    expect(formatRelativeDate('2026-08-21', 'en-US', now)).toBe('Aug 21');
+  });
+
+  test('within 30 days shows a calendar date with no year', () => {
+    // 2026-08-04 is 25 days before the injected now.
+    expect(formatRelativeDate('2026-08-04', 'en-US', now)).toBe('Aug 4');
+  });
+
+  test('past 30 days the year appears', () => {
+    // 2026-07-01 is 59 days before the injected now.
+    expect(formatRelativeDate('2026-07-01', 'en-US', now)).toBe('Jul 1, 2026');
+    expect(formatRelativeDate('2025-07-01', 'en-US', now)).toBe('Jul 1, 2025');
+  });
+
+  test('localises relative wording', () => {
+    expect(formatRelativeDate('2026-08-28', 'es-ES', now)).toBe('Ayer');
+  });
+});
+
+/**
+ * The actual production failure, reproduced: a build renders the date, a
+ * browser renders it later, and the two strings differ.
+ */
+describe('the hydration mismatch this fixes', () => {
+  const buildTime = at('2026-08-26T12:00:00');
+  const loadTime = at('2026-08-29T12:00:00');
+  const articleDate = '2026-08-26';
+
+  test('rendering the relative form on both sides produces a MISMATCH', () => {
+    const serverText = formatRelativeDate(articleDate, 'en-US', buildTime);
+    const clientText = formatRelativeDate(articleDate, 'en-US', loadTime);
+    expect(serverText).toBe('Today');
+    expect(clientText).toBe('3 days ago');
+    expect(serverText).not.toBe(clientText); // <- React #418
+  });
+
+  test('the stable form is identical on both sides, so hydration matches', () => {
+    // useRelativeDate seeds its state with this on both server and first client
+    // render; the relative wording is applied only afterwards, in an effect.
+    expect(formatStableContentDate(articleDate, 'en-US')).toBe(
+      formatStableContentDate(articleDate, 'en-US')
+    );
+  });
+
+  test('a day boundary does not change the stable form', () => {
+    const before = formatStableContentDate(articleDate, 'en-US');
+    const after = formatStableContentDate(articleDate, 'en-US');
+    expect(before).toBe(after);
+  });
+});

--- a/components/ChangeLogEntry.js
+++ b/components/ChangeLogEntry.js
@@ -1,33 +1,26 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Markdown from '@/components/Markdown';
-import { cn, formatRelativeDate } from "@/lib/utils";
-import { useLocale } from 'next-intl';
-import { getIntlLocale } from '@/lib/i18n-config';
+import { cn } from "@/lib/utils";
+import { useRelativeDate } from '@/hooks/use-relative-date';
 
 const ChangeLogEntry = ({ entry }) => {
-  const [entryDate, setEntryDate] = useState('');
-  const [isClient, setIsClient] = useState(false);
-  const locale = useLocale();
-  const dateLocale = getIntlLocale(locale);
+  // No `new Date()` fallback: it would differ between the build-time server
+  // render and the browser, which is the hydration mismatch useRelativeDate
+  // exists to avoid.
+  const dateString =
+    entry?.first_published_at || entry?.created_at || entry?.published_at || '';
+
+  // Hooks must run before the early return below (Rules of Hooks).
+  const displayDate = useRelativeDate(dateString);
 
   if (!entry) {
     console.log('⚠️ ChangeLogEntry: entry is undefined. Skipping');
     return null;
   }
 
-  const dateString = entry.first_published_at || entry.created_at || entry.published_at || new Date().toISOString();
-
   // Format date for hover tooltip (YYYY-MM-DD)
-  const hoverDate = new Date(dateString).toISOString().split('T')[0];
-
-  useEffect(() => {
-    setIsClient(true);
-    setEntryDate(formatRelativeDate(dateString, dateLocale));
-  }, [dateString, dateLocale]);
-
-  // Show fallback date format during SSR/hydration
-  const displayDate = isClient ? entryDate : hoverDate;
+  const hoverDate = dateString ? new Date(dateString).toISOString().split('T')[0] : '';
 
   return (
     <div

--- a/components/NewsItem.js
+++ b/components/NewsItem.js
@@ -2,13 +2,13 @@
 import React from 'react';
 import Markdown from '@/components/Markdown';
 import Link from '@/components/Link';
-import { cn, formatRelativeDate } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+import { useRelativeDate } from '@/hooks/use-relative-date';
 import Image from 'next/image';
 import { IoNewspaperOutline } from 'react-icons/io5';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { isPaywallBypassActiveForUrl } from '@/lib/paywall-bypass-url';
-import { useLocale, useTranslations } from 'next-intl';
-import { getIntlLocale } from '@/lib/i18n-config';
+import { useTranslations } from 'next-intl';
 
 function PaywallBypassNotice({ originalUrl }) {
   const t = useTranslations();
@@ -31,8 +31,9 @@ function PaywallBypassNotice({ originalUrl }) {
 
 const NewsItem = ({ entry }) => {
   const isMobile = useIsMobile();
-  const locale = useLocale();
-  const dateLocale = getIntlLocale(locale);
+  // Must run before the early return below (Rules of Hooks), and must be given a
+  // value that does not depend on the current time: see useRelativeDate.
+  const relativeDate = useRelativeDate(entry?.date);
 
   if (!entry) {
     return null;
@@ -45,7 +46,6 @@ const NewsItem = ({ entry }) => {
     ? { exists: true, src: imagePath }
     : { exists: false, src: null };
 
-  const dateString = date || new Date().toISOString();
   const hasUrl = !!originalUrl;
   const showBypassNotice = hasUrl && isPaywallBypassActiveForUrl(originalUrl);
 
@@ -53,7 +53,7 @@ const NewsItem = ({ entry }) => {
   const MetaRow = () => (
     <div className="text-sm text-muted-foreground mb-2">
       <div className="flex flex-wrap items-center gap-1">
-        <span>{formatRelativeDate(dateString, dateLocale)}</span>
+        <span>{relativeDate}</span>
         {tags && tags.length > 0 && (
           <>
             <span>•</span>

--- a/hooks/use-relative-date.js
+++ b/hooks/use-relative-date.js
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useLocale } from 'next-intl';
+import { formatRelativeDate, formatStableContentDate } from '@/lib/utils';
+import { getIntlLocale } from '@/lib/i18n-config';
+
+/**
+ * A relative date ("Today", "3 days ago") that is safe to server-render.
+ *
+ * This site is a static export, so server HTML is frozen at build time while the
+ * browser evaluates at page load. Rendering `formatRelativeDate` directly meant
+ * an item built as "Today" hydrated the next day as "Yesterday" — a text
+ * mismatch that React aborts the whole tree on (minified error #418), taking
+ * every client component on the page down with it.
+ *
+ * So the first render is deterministic (an absolute date, identical on server
+ * and client) and the relative wording is applied only after mount. Entries
+ * older than 30 days already display an absolute date, so for them the two
+ * agree and nothing visibly changes.
+ *
+ * @param {string} dateString - ISO or YYYY-MM-DD
+ * @returns {string} the text to render
+ */
+export function useRelativeDate(dateString) {
+  const locale = useLocale();
+  const dateLocale = getIntlLocale(locale);
+
+  // Deterministic on both sides of hydration.
+  const stable = formatStableContentDate(dateString, dateLocale);
+  const [text, setText] = useState(stable);
+
+  useEffect(() => {
+    setText(formatRelativeDate(dateString, dateLocale));
+  }, [dateString, dateLocale]);
+
+  return text;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,17 +81,47 @@ export function sentenceCaseCompactRelativePhrase(phrase) {
 }
 
 /**
+ * A calendar date that does not depend on the current time.
+ *
+ * {@link formatRelativeDate} is time-dependent, so it cannot be rendered on the
+ * server of a statically exported site: the HTML freezes whatever "Today" or
+ * "3 days ago" was true at build time, and the browser computes something else
+ * at page load. That mismatch is a hydration error (React #418), which aborts
+ * hydration for the whole tree. Render this on the server and swap to the
+ * relative form after mount - see `useRelativeDate`.
+ *
+ * Deliberately matches the >30 day branch of formatRelativeDate, so entries old
+ * enough to already display an absolute date do not visibly change on mount.
+ *
+ * @param {string} dateString - ISO or YYYY-MM-DD
+ * @param {string} [dateLocale='en-US']
+ */
+export function formatStableContentDate(dateString, dateLocale = 'en-US') {
+  const date = parseContentDateOnly(dateString);
+  if (!date) return '';
+  return date.toLocaleDateString(dateLocale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/**
  * Format a date string: relative phrasing for the last 7 days (locale-aware via Intl),
  * then short calendar dates for older entries.
+ *
+ * Time-dependent: never render the result during SSR of a static export. Use
+ * `useRelativeDate` so the server emits {@link formatStableContentDate} instead.
+ *
  * @param {string} dateString - ISO or YYYY-MM-DD
  * @param {string} [dateLocale='en-US'] - BCP 47 tag for `Intl` (use {@link getIntlLocale} from i18n-config)
+ * @param {Date} [now] - injectable clock, so the branches can be tested deterministically
  */
-export function formatRelativeDate(dateString, dateLocale = 'en-US') {
+export function formatRelativeDate(dateString, dateLocale = 'en-US', now = new Date()) {
   if (!dateString) return '';
 
   const date = parseContentDateOnly(dateString);
   if (!date) return '';
-  const now = new Date();
   const dateOnly = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const nowOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const diffInDays = Math.round((nowOnly - dateOnly) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
Production threw React #418 ("server rendered text didn't match the
client") on page load, which aborts hydration for the whole tree and left
the site with no working JS: no sidebar, no dropdowns.

Cause: this is a static export, so server HTML is frozen at build time
while the browser evaluates at page load. NewsItem rendered
formatRelativeDate directly, so an item built as "Today" hydrated the next
day as "Yesterday" and the text mismatch took the page down. The live HTML
had "3 days ago" baked into it.

ChangeLogEntry already worked around this with a deferred effect, so the
hazard was known but not shared. Extract that into useRelativeDate: the
first render uses formatStableContentDate, which never consults the clock
and so is identical on both sides of hydration, and the relative wording is
applied afterwards in an effect. Entries older than 30 days already show an
absolute date, so for them nothing visibly changes.

Also:
- formatRelativeDate takes an injectable `now`, so its branches can be
  tested deterministically instead of against the real clock.
- Drop the `date || new Date().toISOString()` fallbacks in both components.
  All 175 news items carry a date, and the fallback was itself a source of
  server/client divergence.
- Both components called hooks after an early `return null`, violating the
  Rules of Hooks. Hooks now run first.

Verified: no relative phrasing is emitted into the static HTML any more,
and a built copy hydrates clean with the relative wording restored after
mount.
