### PR TITLE
Move listmonk healthcheck and launcher into source control

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -142,6 +142,36 @@ DOMAIN_NAME=activistchecklist.org
 DOMAIN_WARN_DAYS=45
 DOMAIN_HEALTHCHECK_PING_URL=https://hc-ping.com/your-domain-check-uuid
 
+# === scripts/healthcheck-listmonk.sh + scripts/launch-listmonk.sh
+# Runs on the newsletter server (the box hosting listmonk under PM2), not the site server.
+LISTMONK_HEALTHCHECK_PING_URL=https://hc-ping.com/your-listmonk-check-uuid
+# Public base URL to probe; falls back to LISTMONK_API_URL when unset.
+# LISTMONK_ROOT_URL=https://listmonk.example.com
+# LISTMONK_HEALTH_PATH=/api/health
+# LISTMONK_SUBSCRIPTION_PATH=/subscription
+# LISTMONK_PM2_APP_NAME=listmonk
+#
+# Absolute paths on the newsletter server. These are host specific, so set them in
+# .env.production on that box - no real paths belong in this template.
+# LISTMONK_BIN=/absolute/path/to/listmonk
+# LISTMONK_CONFIG=/absolute/path/to/config.toml
+# LISTMONK_STATIC_DIR=/absolute/path/to/static/
+# LISTMONK_PM2_HOME=/absolute/path/to/.pm2
+# cron does not source ~/.bashrc, so the launcher needs nvm's bin dir pointed out to it.
+# Must match the PM2_HOME your interactive shell uses, or cron drives a second daemon.
+# LISTMONK_NVM_DIR=/absolute/path/to/.nvm
+# LISTMONK_PATH_EXTRA=
+# Restart tuning:
+# LISTMONK_LAUNCH_TIMEOUT=90
+# LISTMONK_START_ATTEMPTS=6
+# LISTMONK_START_RETRY_SLEEP=5
+
+# === scripts/sync-repo.sh
+# Hourly git pull for server checkouts that have no deploy webhook.
+REPO_SYNC_BRANCH=main
+# REPO_SYNC_REMOTE=origin
+REPO_SYNC_HEALTHCHECK_PING_URL=https://hc-ping.com/your-repo-sync-uuid
+
 # === scripts/healthcheck-canary.mjs (warrant canary freshness)
 # Pings on success, suffixed with /fail when the canary is stale or unreadable.
 HEALTHCHECK_CANARY_URL=https://hc-ping.com/your-canary-check-uuid

--- a/scripts/healthcheck-listmonk.sh
+++ b/scripts/healthcheck-listmonk.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Health check + auto-restart for listmonk.
+#
+# Runs on the newsletter server (the box that hosts listmonk under PM2), not on
+# the main site server. Probes the public health API; if listmonk is down it runs
+# launch-listmonk.sh, then pings Healthchecks.io once the service answers again.
+#
+# Cron example (every 5 minutes, plus a catch-up after reboot):
+#   */5 * * * * /path/to/repo/scripts/healthcheck-listmonk.sh
+#   @reboot sleep 60 && /path/to/repo/scripts/healthcheck-listmonk.sh
+#
+# Required env (see .env.production on the newsletter server):
+#   LISTMONK_HEALTHCHECK_PING_URL — Healthchecks.io ping URL
+#   LISTMONK_ROOT_URL             — public base URL (falls back to LISTMONK_API_URL)
+#
+# Optional env:
+#   LISTMONK_HEALTH_PATH / LISTMONK_SUBSCRIPTION_PATH
+#   LISTMONK_HEALTH_MARKER / LISTMONK_SUBSCRIPTION_MARKER
+#   LISTMONK_LAUNCH_SCRIPT     — default: <repo>/scripts/launch-listmonk.sh
+#   LISTMONK_LAUNCH_TIMEOUT    — seconds to allow the launcher (default 90)
+#   LISTMONK_START_ATTEMPTS    — post-start probes (default 6)
+#   LISTMONK_START_RETRY_SLEEP — seconds between probes (default 5)
+#   LOG_DIR / LOG_LINES_KEEP   — shared server log settings
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "healthcheck-listmonk.log" "$(resolve_server_log_lines_keep)"
+
+# Rotate BEFORE redirecting stdout. trim_log replaces the file via mv, so trimming
+# afterwards would leave our fd pointing at the unlinked inode and silently drop
+# every later line.
+trim_log
+exec >> "$LOG_FILE" 2>&1
+
+ROOT_URL="${LISTMONK_ROOT_URL:-${LISTMONK_API_URL:-}}"
+HEALTH_PATH="${LISTMONK_HEALTH_PATH:-/api/health}"
+SUBSCRIPTION_PATH="${LISTMONK_SUBSCRIPTION_PATH:-/subscription}"
+# An unauthenticated GET of the health API returns this; the homepage is not public.
+HEALTH_MARKER="${LISTMONK_HEALTH_MARKER:-\"message\":\"invalid session\"}"
+SUBSCRIPTION_MARKER="${LISTMONK_SUBSCRIPTION_MARKER:-listmonk.app}"
+PING_URL="${LISTMONK_HEALTHCHECK_PING_URL:-}"
+LAUNCH_SCRIPT="${LISTMONK_LAUNCH_SCRIPT:-$SCRIPT_DIR/launch-listmonk.sh}"
+LAUNCH_TIMEOUT="${LISTMONK_LAUNCH_TIMEOUT:-90}"
+START_ATTEMPTS="${LISTMONK_START_ATTEMPTS:-6}"
+START_RETRY_SLEEP="${LISTMONK_START_RETRY_SLEEP:-5}"
+
+echo "=== $(date -Iseconds) healthcheck-listmonk (log: $LOG_FILE) ==="
+
+if [[ -z "$ROOT_URL" ]]; then
+  echo "FATAL: set LISTMONK_ROOT_URL or LISTMONK_API_URL"
+  exit 1
+fi
+
+HEALTH_URL="${ROOT_URL%/}$HEALTH_PATH"
+SUBSCRIPTION_URL="${ROOT_URL%/}$SUBSCRIPTION_PATH"
+
+hc_post() {
+  local url="$1" body="$2"
+  [[ -n "$PING_URL" ]] || return 0
+  # A failed ping must never crash the monitor.
+  curl -fsS --max-time 10 --retry 3 --data-raw "$body" "$url" >/dev/null 2>&1 || true
+}
+
+# 503 pages and Cloudflare errors are long; keep just enough to tell them apart.
+snippet() {
+  printf '%s' "$1" | tr -d '\n' | cut -c1-200
+}
+
+fetch() {
+  curl -s -m 5 "$1" 2>/dev/null || true
+}
+
+service_online=false
+
+HEALTH_BODY="$(fetch "$HEALTH_URL")"
+if grep -qF "$HEALTH_MARKER" <<<"$HEALTH_BODY"; then
+  echo "OK: listmonk API is responding at $HEALTH_URL"
+  service_online=true
+else
+  echo "FAIL: health API check (got: $(snippet "$HEALTH_BODY"))"
+  # Fallback: the subscription page is public even when the API session check moves.
+  SUB_BODY="$(fetch "$SUBSCRIPTION_URL")"
+  if grep -qF "$SUBSCRIPTION_MARKER" <<<"$SUB_BODY"; then
+    echo "OK: listmonk web interface is serving content at $SUBSCRIPTION_URL"
+    service_online=true
+  else
+    echo "FAIL: subscription page check ('$SUBSCRIPTION_MARKER' not found)"
+  fi
+fi
+
+if [[ "$service_online" == false ]]; then
+  echo "Attempting to start listmonk..."
+  if [[ -x "$LAUNCH_SCRIPT" ]]; then
+    # Foreground, with output captured. Backgrounding this into /dev/null is what
+    # hid ~1600 consecutive "pm2: command not found" failures from cron.
+    launch_rc=0
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$LAUNCH_TIMEOUT" "$LAUNCH_SCRIPT" || launch_rc=$?
+    else
+      # macOS has no coreutils timeout; the servers do. Degrade rather than fail.
+      "$LAUNCH_SCRIPT" || launch_rc=$?
+    fi
+    echo "Launch script exited rc=$launch_rc"
+
+    for ((attempt = 1; attempt <= START_ATTEMPTS; attempt++)); do
+      sleep "$START_RETRY_SLEEP"
+      RETRY_BODY="$(fetch "$HEALTH_URL")"
+      if grep -qF "$HEALTH_MARKER" <<<"$RETRY_BODY"; then
+        echo "OK: listmonk started (health API confirmed after $((attempt * START_RETRY_SLEEP))s)"
+        service_online=true
+        break
+      fi
+      echo "  ... attempt $attempt/$START_ATTEMPTS: not up yet (got: $(snippet "$RETRY_BODY"))"
+    done
+
+    [[ "$service_online" == false ]] && echo "FAIL: listmonk did not come back up"
+  else
+    echo "FAIL: launch script missing or not executable: $LAUNCH_SCRIPT"
+  fi
+fi
+
+if [[ "$service_online" == true ]]; then
+  hc_post "${PING_URL%/}" "healthcheck-listmonk ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL"
+  [[ -n "$PING_URL" ]] && echo "Health check ping sent" || echo "No LISTMONK_HEALTHCHECK_PING_URL set; ping skipped"
+else
+  hc_post "${PING_URL%/}/fail" "healthcheck-listmonk failed $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL"
+  [[ -n "$PING_URL" ]] && echo "Sent fail ping - listmonk is down" || echo "listmonk is down (no ping URL configured)"
+  echo "=== Check complete ==="
+  exit 1
+fi
+
+echo "=== Check complete ==="

--- a/scripts/launch-listmonk.sh
+++ b/scripts/launch-listmonk.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Start (or restart) listmonk under PM2 on the newsletter server.
+#
+# Called by scripts/healthcheck-listmonk.sh, and safe to run by hand.
+#
+# IMPORTANT: this runs from cron, which does NOT source ~/.bashrc. Everything an
+# interactive shell gets from .bashrc - nvm's bin dir on PATH, and PM2_HOME - has
+# to be set up explicitly here. Without it `pm2` is simply not found, and because
+# the caller used to discard output the restart failed silently every 5 minutes.
+#
+# Required env (see .env.production on the newsletter server):
+#   LISTMONK_BIN    — absolute path to the listmonk binary
+#   LISTMONK_CONFIG — absolute path to config.toml
+#
+# Optional env:
+#   LISTMONK_STATIC_DIR   — --static-dir passed to listmonk
+#   LISTMONK_PM2_HOME     — PM2 state dir; MUST match the PM2_HOME your shell uses,
+#                           or cron talks to a second, separate PM2 daemon
+#   LISTMONK_PM2_APP_NAME — PM2 process name (default: listmonk)
+#   LISTMONK_NVM_DIR      — nvm install dir to source for node/pm2 on PATH
+#   LISTMONK_PATH_EXTRA   — extra PATH prefix if pm2 lives outside nvm
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+
+APP_NAME="${LISTMONK_PM2_APP_NAME:-listmonk}"
+LISTMONK_BIN="${LISTMONK_BIN:-}"
+LISTMONK_CONFIG="${LISTMONK_CONFIG:-}"
+LISTMONK_STATIC_DIR="${LISTMONK_STATIC_DIR:-}"
+
+if [[ -z "$LISTMONK_BIN" || -z "$LISTMONK_CONFIG" ]]; then
+  echo "FATAL: set LISTMONK_BIN and LISTMONK_CONFIG (see .env.production)" >&2
+  exit 1
+fi
+
+if [[ ! -x "$LISTMONK_BIN" ]]; then
+  echo "FATAL: listmonk binary missing or not executable: $LISTMONK_BIN" >&2
+  exit 1
+fi
+
+# --- cron-safe environment bootstrap ---
+[[ -n "${LISTMONK_PATH_EXTRA:-}" ]] && export PATH="$LISTMONK_PATH_EXTRA:$PATH"
+if [[ -n "${LISTMONK_NVM_DIR:-}" && -s "$LISTMONK_NVM_DIR/nvm.sh" ]]; then
+  export NVM_DIR="$LISTMONK_NVM_DIR"
+  # nvm refuses to load when npm_config_prefix is inherited from a prior setup.
+  unset npm_config_prefix NPM_CONFIG_PREFIX
+  # shellcheck disable=SC1091
+  \. "$NVM_DIR/nvm.sh"
+fi
+[[ -n "${LISTMONK_PM2_HOME:-}" ]] && export PM2_HOME="$LISTMONK_PM2_HOME"
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "FATAL: pm2 not found on PATH ($PATH)." >&2
+  echo "       Set LISTMONK_NVM_DIR or LISTMONK_PATH_EXTRA - cron does not read ~/.bashrc." >&2
+  exit 1
+fi
+
+echo "launch-listmonk: pm2=$(command -v pm2) node=$(command -v node || echo none) PM2_HOME=${PM2_HOME:-<default>}"
+
+# Delete then start so a wedged process never lingers into the new run.
+pm2 delete "$APP_NAME" >/dev/null 2>&1 || true
+
+start_args=(--config "$LISTMONK_CONFIG")
+[[ -n "$LISTMONK_STATIC_DIR" ]] && start_args+=(--static-dir "$LISTMONK_STATIC_DIR")
+
+pm2 start "$LISTMONK_BIN" --name "$APP_NAME" --interpreter none -- "${start_args[@]}"
+start_rc=$?
+
+# Persist the process list so `pm2 resurrect` has something to restore.
+pm2 save >/dev/null 2>&1 || true
+
+exit $start_rc

--- a/scripts/sync-repo.sh
+++ b/scripts/sync-repo.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Keep a server checkout of this repo in sync with the remote.
+#
+# The newsletter server runs cron scripts straight out of a clone but has no
+# deploy webhook, so an hourly pull is how it picks up changes.
+#
+# Cron example:
+#   17 * * * * /path/to/repo/scripts/sync-repo.sh
+#
+# Optional env:
+#   REPO_SYNC_BRANCH              — branch to track (default: main)
+#   REPO_SYNC_REMOTE              — remote name (default: origin)
+#   REPO_SYNC_HEALTHCHECK_PING_URL — Healthchecks.io ping URL
+#   LOG_DIR / LOG_LINES_KEEP      — shared server log settings
+#
+# Fast-forward only: if the checkout ever diverges the sync fails loudly with a
+# /fail ping rather than silently discarding whatever is there.
+#
+set -uo pipefail
+
+# Everything lives in main() so bash parses the whole script before the pull can
+# rewrite this file underneath the running shell.
+main() {
+  local SCRIPT_DIR PROJECT_DIR
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/load-env.sh"
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/log.sh"
+
+  init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "sync-repo.log" "$(resolve_server_log_lines_keep)"
+  trim_log
+  exec >> "$LOG_FILE" 2>&1
+
+  local branch remote ping_url
+  branch="${REPO_SYNC_BRANCH:-main}"
+  remote="${REPO_SYNC_REMOTE:-origin}"
+  ping_url="${REPO_SYNC_HEALTHCHECK_PING_URL:-}"
+
+  echo "=== $(date -Iseconds) sync-repo $PROJECT_DIR ($remote/$branch) ==="
+
+  hc_post() {
+    local url="$1" body="$2"
+    [[ -n "$ping_url" ]] || return 0
+    curl -fsS --max-time 10 --retry 3 --data-raw "$body" "$url" >/dev/null 2>&1 || true
+  }
+
+  fail() {
+    echo "FAIL: $1"
+    hc_post "${ping_url%/}/fail" "sync-repo failed $(date -u +"%Y-%m-%dT%H:%M:%SZ") $1"
+    exit 1
+  }
+
+  cd "$PROJECT_DIR" || fail "cannot cd to $PROJECT_DIR"
+  git rev-parse --git-dir >/dev/null 2>&1 || fail "not a git repository: $PROJECT_DIR"
+
+  local before after
+  before="$(git rev-parse HEAD)"
+
+  git fetch --quiet "$remote" "$branch" || fail "git fetch $remote $branch failed"
+
+  local current
+  current="$(git rev-parse --abbrev-ref HEAD)"
+  if [[ "$current" != "$branch" ]]; then
+    git checkout --quiet "$branch" || fail "cannot checkout $branch (on $current)"
+  fi
+
+  # --ff-only: refuse to invent a merge commit on a server checkout.
+  git merge --ff-only --quiet "$remote/$branch" \
+    || fail "cannot fast-forward to $remote/$branch - checkout has diverged or has local edits"
+
+  after="$(git rev-parse HEAD)"
+
+  if [[ "$before" == "$after" ]]; then
+    echo "OK: already up to date at ${after:0:8}"
+  else
+    echo "OK: ${before:0:8} -> ${after:0:8}"
+    git --no-pager log --oneline "$before..$after" | head -20
+  fi
+
+  hc_post "${ping_url%/}" "sync-repo ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") head=${after:0:8}"
+  echo "=== Sync complete ==="
+}
+
+main "$@"; exit $?


### PR DESCRIPTION
These two scripts lived only on the newsletter server, which is why they
never got the cron environment handling the in-repo healthchecks already
have. Cron does not source ~/.bashrc, and that was the only place nvm's
bin dir reached PATH and PM2_HOME was exported, so every restart attempt
died at "pm2: command not found". The caller discarded output to
/dev/null, so the failure was invisible: 1623 restart attempts, 1611
outright failures, and the 12 apparent successes were transient blips
where listmonk had never actually gone down.

- healthcheck-listmonk.sh: probe, restart, ping. Uses the repo's
  load-env.sh/log.sh conventions, logs the launcher's output instead of
  discarding it, retries the post-start probe 6x5s instead of once at 5s,
  truncates captured error bodies, and rotates via trim_log.
- launch-listmonk.sh: bootstraps nvm and PM2_HOME explicitly, and fails
  loudly if pm2 is still missing rather than exiting quietly.
- sync-repo.sh: hourly fast-forward pull for server checkouts that have
  no deploy webhook.

All host specific values come from env vars; real paths stay in
.env.production on the server and out of .env.template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated health monitoring and restart handling for the Listmonk newsletter service.
  * Added a reliable launcher for starting Listmonk in server environments.
  * Added scheduled repository synchronization with fast-forward updates and health status reporting.
  * Added configuration templates for service monitoring, launching, and repository synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->