### PR TITLE
Deploy secrets to the newsletter server too

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -99,6 +99,14 @@ REMOTE_GIT_BRANCH=main
 REMOTE_SKIP_GIT=0
 REMOTE_SKIP_API=0
 
+# === Newsletter server (listmonk host) - scripts/deploy-secrets.sh
+# The newsletter server is a separate account with its own absolute paths, so it
+# gets its own local env file instead of sharing .env.production.local.
+# Leave these unset to skip that half of deploy:secrets entirely.
+# NEWSLETTER_SSH_HOST=your-newsletter-ssh-alias
+# NEWSLETTER_ENV_PRODUCTION_PATH=/absolute/path/to/repo/.env.production
+# LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE=./.env.production.newsletter.local
+
 # === Server / cron script logs (healthchecks, api monitor, etc.)
 # One directory; each script writes its own file there (e.g. healthcheck-site.log).
 # Tail line count for trim_log rotation (shared by all scripts).

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,1 +1,2 @@
 .env*
+public/webhooks/webhook-secrets.local.php

--- a/scripts/deploy-secrets.sh
+++ b/scripts/deploy-secrets.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# Push secrets/config that are deliberately not in git:
+#   1. .env.production + public/webhooks/ to the main site server
+#   2. .env.production to the newsletter server (the listmonk host)
+#
+# The two servers are different accounts with different absolute paths, so each
+# has its own local source file. Nothing here is committed - see .env.template
+# for the (path-free) list of variables.
+#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -7,14 +16,24 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../.env
 source "$ROOT/.env"
 
+# Turn a possibly-relative path from .env into an absolute one under the repo.
+resolve_local_file() {
+  local path="$1"
+  if [[ "$path" != /* ]]; then
+    path="$ROOT/${path#./}"
+  fi
+  printf '%s' "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Main site server
+# ---------------------------------------------------------------------------
 : "${FTP_HOST:?Set FTP_HOST in .env}"
 : "${FTP_USER:?Set FTP_USER in .env}"
 : "${FTP_DIR:?Set FTP_DIR in .env (remote web root, e.g. web or /public_html)}"
 : "${ENV_PRODUCTION_PATH:?Set ENV_PRODUCTION_PATH in .env (remote .env.production file path)}"
 : "${LOCAL_ENV_PRODUCTION_FILE:=./.env.production.local}"
-if [[ "$LOCAL_ENV_PRODUCTION_FILE" != /* ]]; then
-  LOCAL_ENV_PRODUCTION_FILE="$ROOT/${LOCAL_ENV_PRODUCTION_FILE#./}"
-fi
+LOCAL_ENV_PRODUCTION_FILE="$(resolve_local_file "$LOCAL_ENV_PRODUCTION_FILE")"
 if [[ ! -f "$LOCAL_ENV_PRODUCTION_FILE" ]]; then
   echo "Missing local production env file: $LOCAL_ENV_PRODUCTION_FILE" >&2
   exit 1
@@ -27,10 +46,10 @@ if [[ ! -f "$WEBHOOK_SECRETS_LOCAL" ]]; then
   exit 1
 fi
 
-echo "===> Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."
+echo "===> [site] Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."
 rsync -avz "$LOCAL_ENV_PRODUCTION_FILE" "$FTP_USER@$FTP_HOST:$ENV_PRODUCTION_PATH"
 
-echo "===> Syncing public/webhooks/ to $FTP_HOST:$FTP_DIR/webhooks/ ..."
+echo "===> [site] Syncing public/webhooks/ to $FTP_HOST:$FTP_DIR/webhooks/ ..."
 # Exclude webhook-secrets.local.php from this pass: with --delete, an absent local copy would
 # remove the file from the server; we upload it in the next step instead.
 rsync -avz --delete \
@@ -40,8 +59,31 @@ rsync -avz --delete \
   "$ROOT/public/webhooks/" \
   "$FTP_USER@$FTP_HOST:$FTP_DIR/webhooks/"
 
-echo "===> Uploading webhook-secrets.local.php..."
+echo "===> [site] Uploading webhook-secrets.local.php..."
 rsync -avz "$WEBHOOK_SECRETS_LOCAL" "$FTP_USER@$FTP_HOST:$FTP_DIR/webhooks/"
 
-echo "===> deploy:secrets complete."
+# ---------------------------------------------------------------------------
+# Newsletter server (listmonk host)
+# ---------------------------------------------------------------------------
+# Optional: skipped cleanly when unconfigured. This box runs no webhooks - it
+# only needs its own .env.production for the listmonk cron scripts.
+NEWSLETTER_SSH_HOST="${NEWSLETTER_SSH_HOST:-}"
+NEWSLETTER_ENV_PRODUCTION_PATH="${NEWSLETTER_ENV_PRODUCTION_PATH:-}"
+LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE="${LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE:-./.env.production.newsletter.local}"
 
+if [[ -z "$NEWSLETTER_SSH_HOST" || -z "$NEWSLETTER_ENV_PRODUCTION_PATH" ]]; then
+  echo "===> [newsletter] Skipped - set NEWSLETTER_SSH_HOST and NEWSLETTER_ENV_PRODUCTION_PATH in .env"
+else
+  LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE="$(resolve_local_file "$LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE")"
+  if [[ ! -f "$LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE" ]]; then
+    echo "Missing local newsletter env file: $LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE" >&2
+    exit 1
+  fi
+  echo "===> [newsletter] Uploading .env.production from $LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE..."
+  rsync -avz "$LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE" \
+    "$NEWSLETTER_SSH_HOST:$NEWSLETTER_ENV_PRODUCTION_PATH"
+  # The file carries the listmonk healthchecks ping URL; keep it owner-only.
+  ssh "$NEWSLETTER_SSH_HOST" "chmod 600 '$NEWSLETTER_ENV_PRODUCTION_PATH'"
+fi
+
+echo "===> deploy:secrets complete."


### PR DESCRIPTION
The listmonk cron scripts now read their config from .env.production on the
newsletter server, but deploy:secrets only ever knew about the main site
server. That box is a separate account with different absolute paths, so it
gets its own local source file rather than sharing .env.production.local.

- deploy-secrets.sh: adds an optional second target driven by
  NEWSLETTER_SSH_HOST / NEWSLETTER_ENV_PRODUCTION_PATH /
  LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE, and chmod 600s the uploaded file
  since it carries a healthchecks ping URL. Skips cleanly when unset, so
  nothing changes for anyone without that setup. No webhooks pass: the
  newsletter box does not serve any.
- .worktreeinclude: mirror public/webhooks/webhook-secrets.local.php into
  worktrees, so deploy:secrets can run from one instead of only the main
  checkout.

Real hostnames and paths stay in .env / .env.production.newsletter.local,
both gitignored; .env.template documents the variables with placeholders.
