### PR TITLE
Limit the newsletter box to guides only

### DIFF
--- a/app/[locale]/[...slug]/page.tsx
+++ b/app/[locale]/[...slug]/page.tsx
@@ -306,8 +306,8 @@ export default async function SlugPage({ params }) {
   if (page) {
     const { frontmatter, content, isFallback } = page;
 
-    // Pages do not get the auto-inserted newsletter CTA (guides do). Editors can
-    // still place a manual <InlineCta /> in the page body if they want one.
+    // The newsletter CTA is guides-only: pages get neither the auto-inserted one
+    // nor a manual <InlineCta /> (components/pages/Page.js renders it as null).
     const serializedBody = content ? await serializeMdx(content) : null;
 
     // Resolve any checklist items embedded in the page via <ChecklistItem slug="…" />

--- a/components/pages/Page.js
+++ b/components/pages/Page.js
@@ -11,6 +11,11 @@ import { LOCALES } from "@/lib/i18n-config";
 import PageNotices from '@/components/layout/PageNotices';
 import AnswerCapsule from '@/components/AnswerCapsule';
 
+// The newsletter CTA belongs to guides only. Neutralizing the component here
+// (rather than only stripping it from the MDX) also covers translated copies
+// that still carry the tag until Crowdin catches up.
+const pageMdxComponents = { ...mdxComponents, InlineCta: () => null };
+
 function parseRelatedGuides(value) {
   if (Array.isArray(value)) return value.filter(Boolean);
   if (typeof value !== 'string') return [];
@@ -28,8 +33,8 @@ function parseRelatedGuides(value) {
  *   - serializedBody: next-mdx-remote compiled MDX
  *   - locale: BCP 47 locale string for date formatting (provided by parent Server Component)
  *
- * Unlike guides, pages do not get the auto-inserted newsletter CTA. A page can
- * still include a manual <InlineCta /> in its MDX body.
+ * The newsletter CTA is a guides-only treatment, so pages neither get the
+ * auto-inserted one nor render a manual <InlineCta /> left in their MDX.
  */
 export default function Page({
   frontmatter,
@@ -59,7 +64,7 @@ export default function Page({
       <AnswerCapsule text={frontmatter.answerCapsule} />
       <div className="prose prose-slate max-w-none">
         {serializedBody && (
-          <MDXRemote {...serializedBody} components={mdxComponents} />
+          <MDXRemote {...serializedBody} components={pageMdxComponents} />
         )}
       </div>
       {relatedGuideSlugs.length > 0 && (

--- a/content/en/pages/proton.mdx
+++ b/content/en/pages/proton.mdx
@@ -46,8 +46,6 @@ Using encrypted email and docs can protect you in a number of situations, but it
 
 </section>
 
-<InlineCta />
-
 <section id="why-useful">
 
 ## Why Proton's services are useful for activists


### PR DESCRIPTION
The inline newsletter CTA is a guides-only treatment, but pages could
still show one: /proton/ had a manual <InlineCta /> in its MDX, and the
translated copies of that page carried the tag too.

Drop the tag from the English page and render InlineCta as null in the
page renderer, so a stray tag in any page (including translations that
Crowdin hasn't resynced yet) can't reintroduce the box.

Fixes #475
