### PR TITLE
Make required PR checks report on Crowdin l10n_* PRs

### DIFF
--- a/.github/workflows/l10n-check-watchdog.yml
+++ b/.github/workflows/l10n-check-watchdog.yml
@@ -1,0 +1,74 @@
+# Makes the required PR checks actually report on Crowdin's l10n_* pull requests.
+#
+# Crowdin opens and pushes to l10n_* branches, and GitHub delivers those webhooks
+# (Railway and CodeRabbit post their checks), but GitHub Actions creates no workflow
+# run for them - verified on PR #601, whose head SHA had zero entries in
+# `actions/runs?head_sha=...` while its Railway and CodeRabbit check suites existed.
+# With no run, the required contexts from pr-checks.yml never report and the PR sits
+# on "Expected - waiting for status to be reported" until someone pushes a commit
+# from their own account.
+#
+# `schedule` fires as the repository itself, so it is unaffected by whatever
+# suppresses the pull_request runs. This job dispatches pr-checks.yml at the head of
+# any open l10n_* PR that has no run of its own; those check runs attach to the PR's
+# head SHA and satisfy the branch ruleset.
+#
+# No PAT needed: workflow_dispatch is an explicit exception to the rule that events
+# triggered by GITHUB_TOKEN do not create new workflow runs.
+
+name: l10n check watchdog
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: l10n-check-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
+jobs:
+  ensure_checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Dispatch pr-checks for l10n PRs with no Actions run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh pr list --repo "$REPO" --state open --limit 50 \
+            --json number,headRefName,headRefOid \
+            --jq '.[] | select(.headRefName | startswith("l10n_")) | [.number, .headRefName, .headRefOid] | @tsv' \
+            > prs.tsv
+
+          if [ ! -s prs.tsv ]; then
+            echo "No open l10n_* pull requests - nothing to do."
+            exit 0
+          fi
+
+          while IFS="$(printf '\t')" read -r number branch sha; do
+            [ -n "${sha:-}" ] || continue
+
+            # Scoped to pr-checks.yml so the count can't be satisfied by some other
+            # workflow, and so re-dispatching is idempotent once a run exists.
+            runs=$(gh api \
+              "repos/$REPO/actions/workflows/pr-checks.yml/runs?head_sha=$sha" \
+              --jq '.total_count')
+
+            if [ "$runs" != "0" ]; then
+              echo "PR #$number ($branch @ ${sha:0:8}): $runs pr-checks run(s) already."
+              continue
+            fi
+
+            echo "PR #$number ($branch @ ${sha:0:8}): no pr-checks run - dispatching."
+            gh workflow run pr-checks.yml --repo "$REPO" --ref "$branch"
+          done < prs.tsv

--- a/__tests__/lib-updates-result-logic.test.js
+++ b/__tests__/lib-updates-result-logic.test.js
@@ -717,7 +717,7 @@ describe('buildDeviceMaxOsWarning', () => {
     const product = snap.products.find((p) => p.id === 'iphone');
     const r = product.releases.find((x) => x.id === '12-pro');
     const reminder = buildLatestOsReminder(snap, product, r);
-    expect(buildDeviceMaxOsWarning(snap, product, r, reminder)).toBeNull();
+    expect(buildDeviceMaxOsWarning(snap, product, r, reminder, NOW)).toBeNull();
   });
 
   it('iPhone 8 (max iOS 16, family latest 26, 16 still EOL) → older-os-eol', () => {
@@ -725,7 +725,7 @@ describe('buildDeviceMaxOsWarning', () => {
     const product = snap.products.find((p) => p.id === 'iphone');
     const r = product.releases.find((x) => x.id === '8');
     const reminder = buildLatestOsReminder(snap, product, r);
-    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder);
+    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder, NOW);
     expect(warn.kind).toBe('older-os-eol');
     expect(warn.maxMajor).toBe(16);
     expect(warn.latestMajor).toBe(26);
@@ -736,7 +736,7 @@ describe('buildDeviceMaxOsWarning', () => {
     const product = snap.products.find((p) => p.id === 'iphone');
     const r = product.releases.find((x) => x.id === '6');
     const reminder = buildLatestOsReminder(snap, product, r);
-    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder);
+    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder, NOW);
     expect(warn.kind).toBe('older-os-eol');
     expect(warn.maxVersion).toBe('12.5.8');
   });
@@ -771,7 +771,7 @@ describe('buildDeviceMaxOsWarning', () => {
     const product = snap.products.find((p) => p.id === 'macbook-pro');
     const r = product.releases[0];
     const reminder = buildLatestOsReminder(snap, product, r);
-    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder);
+    const warn = buildDeviceMaxOsWarning(snap, product, r, reminder, NOW);
     expect(warn.kind).toBe('older-os');
     expect(warn.maxCodename).toBe('Sonoma');
     expect(warn.latestCodename).toBe('Tahoe');

--- a/lib/updates/result-logic.js
+++ b/lib/updates/result-logic.js
@@ -574,8 +574,11 @@ export function buildStuckOnOldOsClassification(release, now = new Date()) {
  * Variants:
  *   'older-os'    → device max < family latest, but device's max is still receiving updates
  *   'older-os-eol' → device max < family latest AND device's max is itself EOL
+ *
+ * `now` is injectable so callers (and tests) can pin the EOL comparison instead of
+ * reading the wall clock, matching classifyResult.
  */
-export function buildDeviceMaxOsWarning(snapshot, product, release, reminder) {
+export function buildDeviceMaxOsWarning(snapshot, product, release, reminder, now = new Date()) {
   if (!reminder) return null;
   if (reminder.case !== 'specific-version') return null;
   if (reminder.isAtFamilyLatest) return null;
@@ -587,7 +590,7 @@ export function buildDeviceMaxOsWarning(snapshot, product, release, reminder) {
   // Mirror classifyResult's EOL semantics: an OS major is EOL if the upstream
   // flag is set OR its eolFrom has passed, even if the snapshot hasn't yet
   // flipped isEol=true (cron-window race when an EOL date passes mid-day).
-  if (target.isEol || isPast(target.eolFrom)) {
+  if (target.isEol || isPast(target.eolFrom, now)) {
     return {
       kind: 'older-os-eol',
       osProduct: reminder.osProduct,


### PR DESCRIPTION
Crowdin opens and pushes to `l10n_*` branches, and GitHub delivers those webhooks (Railway and CodeRabbit post their checks), but **GitHub Actions creates no workflow run for them.**

Verified on #601: its head SHA has zero entries in `actions/runs?head_sha=...` while its Railway and CodeRabbit check suites exist. With no run, the required `pr-checks` contexts never report and the PR sits on "Expected — waiting for status to be reported" until someone pushes a commit from their own account.

Not a branch-reuse problem: `delete_branch_on_merge` is on and working, and `l10n_main` was recreated fresh off main 74s after #498 merged. A brand-new branch with a brand-new PR still got zero runs.

## What this adds

`l10n-check-watchdog.yml` — runs on `schedule` (cron fires as the repository, so it is unaffected by whatever suppresses the `pull_request` runs) and dispatches `pr-checks.yml` at the head of any open `l10n_*` PR that has no run of its own. Those check runs attach to the PR head SHA and satisfy the ruleset.

- No PAT needed: `workflow_dispatch` is an explicit exception to the rule that events triggered by `GITHUB_TOKEN` do not create new workflow runs.
- Idempotent: the run count is scoped to `pr-checks.yml`, so once a run exists it stops dispatching.
- On a dispatch `github.head_ref` is empty, so the `l10n_` guards in `pr-checks.yml` do not apply and `pr_quality` runs for real against the translated content instead of skipping.

## Companion change (already applied, not in this diff)

The **Protect Main - checks** ruleset required `pr_build` + `pr_quality`, two jobs that skip conditionally. It now requires `merge_gate`, the unconditional `if: always()` gate `pr-checks.yml` already declares as "the merge gate."

## Tests

No vitest coverage: this is a workflow with a shell loop, so running it is the test. The TSV parsing loop and both `gh` API calls it depends on were verified by hand against this repo.