### PR TITLE
Fix 10 security alerts, sweep pnpm overrides, add autofix workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,11 @@ updates:
     # either already fixed upstream or never a hold at all, while two real
     # blockers had no record. Re-test before trusting a reason below.
     #
-    # Overrides in pnpm-workspace.yaml are a separate mechanism: uncommented
-    # entries there are security floors (minimums), not holds.
+    # Overrides in pnpm-workspace.yaml are the mirror image of this list:
+    # these are upgrades we declined, those are upgrades Dependabot could
+    # not offer (it will not PR a transitive-only fix). Those are floors,
+    # these are holds, and each entry there carries its own "delete it
+    # when" check. The 2026-09-03 sweep deleted 11 of 18 of them.
     ignore:
       # typescript: BLOCKER LIFTED 2026-08-28, not yet taken.
       #   Was: Next 15 could not build with the TS7 native compiler ("does not

--- a/.github/workflows/security-autofix.yml
+++ b/.github/workflows/security-autofix.yml
@@ -1,0 +1,247 @@
+# Daily sweep for security alerts that Dependabot structurally cannot fix.
+#
+# Dependabot fixes a transitive vulnerability by bumping the PARENT to a release
+# that already depends on a patched version. It never does a lockfile-only bump,
+# and it will not write a pnpm override. So when the parent has no such release,
+# the alert just sits open forever with no PR. On 2026-09-03 ten alerts had piled
+# up that way. This closes that gap.
+#
+# There is no `dependabot_alert` workflow trigger, so this polls on a schedule.
+#
+# Two outcomes, matching the two cases documented in pnpm-workspace.yaml:
+#
+#   - the parent's range already allows the fix, the lockfile is just stuck
+#     → `pnpm update --depth Infinity` moves it → opens a PR
+#   - a parent's range CAPS us below the fix
+#     → needs an override with a hand-written "delete it when" annotation
+#     → opens an issue, because that annotation is a judgment call
+#
+# Runs daily at 07:00 UTC, after Dependabot's own daily scan. Manual
+# `workflow_dispatch` included. Note that GitHub disables scheduled workflows
+# after 60 days without repository activity.
+
+name: Security autofix
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: security-autofix
+  cancel-in-progress: false
+
+jobs:
+  autofix:
+    if: github.repository == 'ActivistChecklist/ActivistChecklist'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm run install:ci
+
+      # ── What is currently vulnerable ──────────────────────────────────────
+      - name: Audit
+        id: audit
+        run: |
+          pnpm audit --json > audit-before.json || true
+          node <<'EOF' >> "$GITHUB_OUTPUT"
+            const fs = require('fs');
+            let report = {};
+            try {
+              report = JSON.parse(fs.readFileSync('audit-before.json', 'utf8'));
+            } catch {
+              // pnpm emits nothing parseable when the registry is unreachable.
+              // Treat that as "nothing to do" rather than inventing an update.
+              console.log('packages=');
+              console.log('count=0');
+              process.exit(0);
+            }
+            const advisories = Object.values(report.advisories || {});
+            const packages = [...new Set(advisories.map((a) => a.module_name))].sort();
+            console.log(`packages=${packages.join(' ')}`);
+            console.log(`count=${advisories.length}`);
+          EOF
+          echo '----- advisories -----'
+          node -e 'const r=JSON.parse(require("fs").readFileSync("audit-before.json","utf8"));for(const a of Object.values(r.advisories||{}))console.log(a.module_name,a.severity,a.github_advisory_id,a.vulnerable_versions,"-> fixed",a.patched_versions)' || true
+
+      - name: Nothing to do
+        if: steps.audit.outputs.count == '0'
+        run: echo 'No open advisories. Exiting.'
+
+      # ── Try the lockfile-only nudge ───────────────────────────────────────
+      # Deliberately NOT `pnpm audit --fix`: its "update" method runs a broad
+      # update and rewrites ranges in package.json (verified 2026-09-03 --
+      # it bumped satori while fixing zero vulnerabilities). `pnpm update
+      # --depth Infinity <pkg>` touches only the named transitive entries.
+      - name: Nudge stuck lockfile entries
+        if: steps.audit.outputs.count != '0'
+        run: |
+          echo "Updating: ${{ steps.audit.outputs.packages }}"
+          pnpm update --depth Infinity ${{ steps.audit.outputs.packages }}
+
+      # package.json must not move. If it did, something changed upstream in
+      # pnpm's behaviour and this workflow should stop rather than open a PR
+      # that quietly widens a dependency range.
+      - name: Assert package.json untouched
+        if: steps.audit.outputs.count != '0'
+        run: git diff --exit-code -- package.json pnpm-workspace.yaml
+
+      - name: Re-audit
+        id: reaudit
+        if: steps.audit.outputs.count != '0'
+        run: |
+          pnpm audit --json > audit-after.json || true
+          node <<'EOF' >> "$GITHUB_OUTPUT"
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            let advisories = [];
+            try {
+              const report = JSON.parse(fs.readFileSync('audit-after.json', 'utf8'));
+              advisories = Object.values(report.advisories || {});
+            } catch {
+              advisories = [];
+            }
+            const lockChanged =
+              execSync('git status --porcelain -- pnpm-lock.yaml').toString().trim() !== '';
+            console.log(`remaining=${advisories.length}`);
+            console.log(`lock_changed=${lockChanged}`);
+            const lines = advisories.map(
+              (a) =>
+                `- \`${a.module_name}\` ${a.severity} — [${a.github_advisory_id}](https://github.com/advisories/${a.github_advisory_id}), affects \`${a.vulnerable_versions}\`, fixed in \`${a.patched_versions}\``
+            );
+            console.log('remaining_list<<REMAINING_EOF');
+            console.log(lines.join('\n'));
+            console.log('REMAINING_EOF');
+            // One advisory can appear twice when a package has two live majors
+            // (fast-uri did), so dedupe or the fingerprint won't match a rerun.
+            const ids = [...new Set(advisories.map((a) => a.github_advisory_id))].sort();
+            console.log(`fingerprint=${ids.join(',')}`);
+          EOF
+
+      # ── Path A: the nudge worked. Verify, then PR. ────────────────────────
+      - name: Unit tests
+        if: steps.reaudit.outputs.remaining == '0' && steps.reaudit.outputs.lock_changed == 'true'
+        run: pnpm test
+
+      - name: Static export build
+        if: steps.reaudit.outputs.remaining == '0' && steps.reaudit.outputs.lock_changed == 'true'
+        run: pnpm buildstatic
+
+      - name: Open PR
+        if: steps.reaudit.outputs.remaining == '0' && steps.reaudit.outputs.lock_changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          # A PAT, not GITHUB_TOKEN: PRs opened with GITHUB_TOKEN do not trigger
+          # other workflows, so pr-checks.yml would never run on them.
+          token: ${{ secrets.SECURITY_AUTOFIX_TOKEN }}
+          add-paths: pnpm-lock.yaml
+          commit-message: 'Security: bump ${{ steps.audit.outputs.packages }} in lockfile'
+          title: 'Security: lockfile bump for ${{ steps.audit.outputs.packages }}'
+          body: |
+            Dependabot opened alerts for these packages but could not PR a fix: they are transitive-only, and its npm updater bumps the *parent* rather than the lockfile entry.
+
+            Their parents' ranges already allowed the patched versions — the lockfile was simply stuck, because pnpm never re-resolves an existing entry on a plain install. `pnpm update --depth Infinity ${{ steps.audit.outputs.packages }}` moved them. No override needed, and `package.json` is untouched.
+
+            Cleared ${{ steps.audit.outputs.count }} advisor(y/ies). `pnpm audit` is clean, unit tests pass, and `pnpm buildstatic` succeeds on this branch.
+
+            Worth a skim of the lockfile diff anyway: a transitive bump can pull in a new major further down the tree.
+
+            *Opened automatically by `.github/workflows/security-autofix.yml`. See the overrides block in `pnpm-workspace.yaml` for why this exists.*
+          branch: security/lockfile-autofix
+          delete-branch: true
+          labels: security 🔐
+
+      # ── Path B: verification failed, or a parent caps us. Escalate. ───────
+      - name: Open issue when a fix needs human judgment
+        if: always() && steps.audit.outputs.count != '0' && (failure() || steps.reaudit.outputs.remaining != '0')
+        uses: actions/github-script@v9
+        env:
+          REMAINING_LIST: ${{ steps.reaudit.outputs.remaining_list }}
+          REMAINING: ${{ steps.reaudit.outputs.remaining }}
+          FINGERPRINT: ${{ steps.reaudit.outputs.fingerprint }}
+          PACKAGES: ${{ steps.audit.outputs.packages }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const remaining = process.env.REMAINING || '0';
+            const capped = remaining !== '0';
+            const fingerprint = `<!-- security-autofix-fingerprint: ${process.env.FINGERPRINT || 'verify-failed'} -->`;
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security 🔐',
+              per_page: 50,
+            });
+            const dup = existing.find((i) => (i.body || '').includes(fingerprint));
+            if (dup) {
+              core.info(`Open issue with same fingerprint already exists: #${dup.number}`);
+              return;
+            }
+
+            const body = capped
+              ? [
+                  `The daily security sweep could not close ${remaining} advisor(y/ies) with a lockfile bump. That means a parent's range **caps us below the fix**, so this needs an override in \`pnpm-workspace.yaml\`.`,
+                  '',
+                  process.env.REMAINING_LIST,
+                  '',
+                  '## How to resolve',
+                  '',
+                  '1. Find who is capping the version:',
+                  '   ```bash',
+                  '   npm view <parent>@<locked-version> dependencies',
+                  '   ```',
+                  '2. Add a floor to the `overrides:` block in `pnpm-workspace.yaml`. Scope it per-major (`pkg@3`) if the tree carries more than one live major — an unscoped floor will drag every consumer onto the newest major.',
+                  '3. Annotate it with who is capping us and a **checkable** "delete it when" condition. That annotation is the whole reason this is an issue and not an automatic PR.',
+                  '4. `pnpm install && pnpm audit --audit-level=low && pnpm test && pnpm buildstatic`',
+                  '',
+                  'Read the header of that overrides block first — it explains the invariant (a floor is justified only when a parent caps us) and the one-minute check for retiring an entry later.',
+                ].join('\n')
+              : [
+                  `The daily security sweep bumped \`${process.env.PACKAGES}\` in the lockfile to clear open advisories, but **verification failed** — tests or the static build did not pass on the result.`,
+                  '',
+                  'No PR was opened. A transitive bump can pull a new major further down the tree, which is most likely what happened here.',
+                  '',
+                  `[View the failing run](${process.env.RUN_URL})`,
+                  '',
+                  '## How to resolve',
+                  '',
+                  '```bash',
+                  `pnpm update --depth Infinity ${process.env.PACKAGES}`,
+                  'pnpm test && pnpm buildstatic',
+                  '```',
+                  '',
+                  'Then either fix the breakage, or pin the offending package with an annotated entry in the `overrides:` block of `pnpm-workspace.yaml`.',
+                ].join('\n');
+
+            const title = capped
+              ? `Security: ${remaining} advisor(y/ies) need a pnpm override`
+              : `Security: lockfile bump for ${process.env.PACKAGES} fails verification`;
+
+            const { data: created } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [body, '', '---', '', '*Opened automatically by `.github/workflows/security-autofix.yml`.*', '', fingerprint].join('\n'),
+              labels: ['security 🔐'],
+            });
+            core.info(`Opened issue #${created.number}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,25 +6,9 @@ settings:
 
 overrides:
   '@radix-ui/react-slot': 1.3.3
-  picomatch: '>=4.0.4'
-  systeminformation: '>=5.31.0'
-  brace-expansion: ^2.0.3
-  lodash: '>=4.18.0'
-  markdown-it: '>=14.1.1'
-  ajv: '>=8.18.0'
-  rollup: '>=4.59.0'
-  basic-ftp: '>=5.2.2'
-  undici: '>=8.9.0'
-  yauzl: '>=3.2.1'
-  ws@7: '>=7.5.11'
-  ws@8: '>=8.21.0'
-  qs: '>=6.15.2'
-  vite: '>=8.0.16'
-  postcss: '>=8.5.17'
-  esbuild: '>=0.28.1'
-  js-yaml@3: '>=3.15.1 <4'
-  js-yaml@4: '>=4.3.1 <5'
+  postcss: '>=8.5.23'
   sharp: '>=0.35.0'
+  js-yaml@4: '>=4.3.1 <5'
 
 importers:
 
@@ -272,7 +256,7 @@ importers:
         specifier: ^1.5.2
         version: 1.5.2
       postcss:
-        specifier: '>=8.5.17'
+        specifier: '>=8.5.23'
         version: 8.5.26
       prettier:
         specifier: ^3.9.6
@@ -299,7 +283,7 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       vite:
-        specifier: '>=8.0.16'
+        specifier: ^8.2.2
         version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
@@ -641,7 +625,7 @@ packages:
       '@standard-schema/spec': ^1.0.0
       '@typeschema/main': '>=0.13.7'
       '@vinejs/vine': ^2.0.0 || ^3.0.0 || ^4.0.0
-      ajv: '>=8.18.0'
+      ajv: ^8.12.0
       ajv-errors: ^3.0.0
       ajv-formats: ^2.1.1
       arktype: ^2.0.0
@@ -874,11 +858,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.12.3':
-    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+  '@internationalized/date@3.12.4':
+    resolution: {integrity: sha512-M1dEn4c1U1HsSlaVR8upZtSqvXrTkHDfv18H01uCSJyjVLDxnBR38v/fMxecmlwXKR4i9HeZcmgQAPE6A+aGJQ==}
 
-  '@internationalized/number@3.6.7':
-    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+  '@internationalized/number@3.6.8':
+    resolution: {integrity: sha512-8UmMFia46DUt+k97zKd9fKWXcWHR+k8ae3eYzILETuT2KbIvLyOfac7zesw+sJdRAAZ7Q9pM1Mk22aXp2LD0Ig==}
 
   '@internationalized/string@3.2.10':
     resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
@@ -2422,7 +2406,7 @@ packages:
     resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=8.0.16'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2467,7 +2451,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: '>=8.18.0'
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -2545,8 +2529,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base16@1.0.0:
     resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
@@ -2564,8 +2549,8 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  basic-ftp@6.2.0:
-    resolution: {integrity: sha512-H8eLjhoYPbOI717FLP8fGE7XInkMI7Ucj/ft0fp1avABtSiV5Bb2kYzScnOqlvJZs/KJZypr9Mp5zJmhaPFAEg==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
   binary-extensions@2.3.0:
@@ -2575,8 +2560,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3024,11 +3010,11 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fastify-cli@8.0.0:
     resolution: {integrity: sha512-7Jme/6on3e+IbEGr7D9S1QF1KAahNnsTOcS8rcKzwluCtr54+UA8BetdFxRYyN+zO1yNQnM1NlD00xfwkLYLjw==}
@@ -3059,7 +3045,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4056,6 +4042,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -4172,8 +4162,8 @@ packages:
   pure-color@1.3.0:
     resolution: {integrity: sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4697,9 +4687,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
@@ -4825,7 +4815,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.4.0 || ^0.5.0
-      esbuild: '>=0.28.1'
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4877,7 +4867,7 @@ packages:
       '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=8.0.16'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4959,8 +4949,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.3:
-    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5239,7 +5229,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
 
   '@fastify/cors@11.3.0':
     dependencies:
@@ -5442,11 +5432,11 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@internationalized/date@3.12.3':
+  '@internationalized/date@3.12.4':
     dependencies:
       '@swc/helpers': 0.5.23
 
-  '@internationalized/number@3.6.7':
+  '@internationalized/number@3.6.8':
     dependencies:
       '@swc/helpers': 0.5.23
 
@@ -5483,8 +5473,8 @@ snapshots:
       '@emotion/sheet': 1.4.0
       '@emotion/utils': 1.4.2
       '@floating-ui/react': 0.24.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@internationalized/date': 3.12.3
-      '@internationalized/number': 3.6.7
+      '@internationalized/date': 3.12.4
+      '@internationalized/number': 3.6.8
       '@internationalized/string': 3.2.10
       '@react-types/shared': 3.36.1(react@19.2.8)
       '@types/react': 19.2.18
@@ -5503,8 +5493,8 @@ snapshots:
       '@braintree/sanitize-url': 6.0.4
       '@emotion/weak-memoize': 0.3.1
       '@floating-ui/react': 0.24.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@internationalized/date': 3.12.3
-      '@internationalized/number': 3.6.7
+      '@internationalized/date': 3.12.4
+      '@internationalized/number': 3.6.8
       '@internationalized/string': 3.2.10
       '@keystar/ui': 0.9.6(next@16.3.3(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-aria@3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-stately@3.48.0(react@19.2.8))(react@19.2.8)
       '@markdoc/markdoc': 0.4.0(@types/react@19.2.18)(react@19.2.8)
@@ -5978,7 +5968,7 @@ snapshots:
       debug: 4.3.7
       eventemitter2: 6.4.9
       extrareqp2: 1.0.0(debug@4.3.7)
-      ws: 8.21.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6966,7 +6956,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6989,7 +6979,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.5
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -7028,7 +7018,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   base16@1.0.0: {}
 
@@ -7040,15 +7030,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  basic-ftp@6.2.0: {}
+  basic-ftp@5.3.1: {}
 
   binary-extensions@2.3.0: {}
 
   boolbase@1.0.0: {}
 
-  brace-expansion@2.1.4:
+  brace-expansion@5.0.9:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7118,7 +7108,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 8.10.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -7493,7 +7483,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -7503,9 +7493,9 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fastify-cli@8.0.0:
     dependencies:
@@ -7661,7 +7651,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 6.2.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -8524,13 +8514,13 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.5
+      picomatch: 2.3.2
 
   mime@1.6.0: {}
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 2.1.4
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -8699,7 +8689,7 @@ snapshots:
       chardet: 2.2.0
       cheerio: 1.2.0
       iconv-lite: 0.7.3
-      undici: 8.10.0
+      undici: 7.29.0
 
   opener@1.5.2: {}
 
@@ -8795,6 +8785,8 @@ snapshots:
       tslib: 1.14.1
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
 
@@ -8903,7 +8895,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.7.2
       tx2: 1.0.5
-      ws: 8.21.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9012,7 +9004,7 @@ snapshots:
 
   pure-color@1.3.0: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -9029,8 +9021,8 @@ snapshots:
 
   react-aria@3.50.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@internationalized/date': 3.12.3
-      '@internationalized/number': 3.6.7
+      '@internationalized/date': 3.12.4
+      '@internationalized/number': 3.6.8
       '@internationalized/string': 3.2.10
       '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.23
@@ -9096,8 +9088,8 @@ snapshots:
 
   react-stately@3.48.0(react@19.2.8):
     dependencies:
-      '@internationalized/date': 3.12.3
-      '@internationalized/number': 3.6.7
+      '@internationalized/date': 3.12.4
+      '@internationalized/number': 3.6.8
       '@internationalized/string': 3.2.10
       '@react-types/shared': 3.36.1(react@19.2.8)
       '@swc/helpers': 0.5.23
@@ -9131,7 +9123,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 4.0.5
+      picomatch: 2.3.2
 
   readdirp@5.1.1: {}
 
@@ -9608,7 +9600,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.10.0: {}
+  undici@7.29.0: {}
 
   unicode-trie@2.0.0:
     dependencies:
@@ -9627,7 +9619,7 @@ snapshots:
 
   union@0.5.0:
     dependencies:
-      qs: 6.15.3
+      qs: 6.16.0
 
   unist-util-is@6.0.1:
     dependencies:
@@ -9667,7 +9659,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.15.3
+      qs: 6.16.0
 
   urql@4.2.2(@urql/core@5.2.0(graphql@16.14.2))(react@19.2.8):
     dependencies:
@@ -9833,7 +9825,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.3: {}
+  ws@8.21.0: {}
 
   xml-js@1.6.11:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,33 +13,127 @@ onlyBuiltDependencies:
   - sharp
 
 overrides:
-  # Uncommented entries are security floors (minimums for transitive deps),
-  # not holds. Declined upgrades are recorded in .github/dependabot.yml, next
-  # to the ignore rules that enforce them.
+  # ── Why this block exists ────────────────────────────────────────────
+  # Dependabot cannot fix a transitive-only dependency for us. Its npm
+  # updater fixes a transitive vuln by bumping the PARENT to a release that
+  # already depends on a patched version. It does not do lockfile-only
+  # bumps, and it will not write a pnpm override. So when the parent has no
+  # such release -- ajv is already latest; next and pm2 ship pinned old
+  # copies -- the alert just sits open with "Dependabot cannot update X to a
+  # non-vulnerable version", forever, with no PR.
   #
-  # react-slot: floor, not a ceiling. 1.3.3 is the current latest stable. Guards
-  # against a stale parallel node_modules resolving an old copy ("createSlot is
-  # not exported"); see the outputFileTracingRoot note in next.config.js.
+  # Every entry below is a hand-applied fix for exactly that. It is the
+  # counterpart to the ignore rules in .github/dependabot.yml: those record
+  # upgrades we DECLINED, these record upgrades Dependabot could not OFFER.
+  #
+  # But reach for an override LAST, and only when a parent's range actually
+  # CAPS us below the fix. Usually the parent allows the patched version
+  # and the lockfile is merely stuck on an old entry, because pnpm never
+  # re-resolves an existing entry on a plain install. That case needs no
+  # override at all -- it needs a targeted nudge:
+  #
+  #     pnpm update --depth Infinity <pkg> [<pkg>...]
+  #
+  # which is the lockfile-only bump Dependabot refuses to do. It leaves
+  # package.json alone; verified 2026-09-03 that it moved fast-uri and qs
+  # and touched nothing else. Do NOT use `pnpm audit --fix update` for
+  # this -- on the same tree it ran a broad update and bumped satori's
+  # range in package.json while fixing zero vulnerabilities.
+  #
+  # All ten alerts on the 2026-09-03 sweep (fast-uri x8, qs x2) were this
+  # case. Floors for them would have been four lines of permanent debt in
+  # exchange for a one-time nudge.
+  #
+  # These are floors, never ceilings. A hold belongs in dependabot.yml.
+  #
+  # ── None of these are permanent. How to retire one ───────────────────
+  # Parents catch up, and a stale override silently forces a major on some
+  # transitive consumer for no reason. The check is the same for every
+  # entry and takes about a minute:
+  #
+  #   1. comment the line out
+  #   2. pnpm install --lockfile-only
+  #   3. pnpm audit --audit-level=low
+  #   4. git checkout pnpm-lock.yaml   (then re-install for real)
+  #
+  # If audit is clean, the override is dead -- delete it. Each entry below
+  # records who is capping the version, so you can tell whether re-testing
+  # is even worth it.
+  #
+  # Last swept 2026-09-03, against pnpm 11.4.0 / next 15.5.23 / pm2 7.0.3.
+  # That sweep deleted 16 of 20 entries and added none. Expect that rot
+  # rate: the default answer to "should this be an override?" is no.
+  # ─────────────────────────────────────────────────────────────────────
+
+  # NOT a security floor. 1.3.3 is current latest stable. Guards against a
+  # stale parallel node_modules resolving an old copy ("createSlot is not
+  # exported"); see the outputFileTracingRoot note in next.config.js.
+  # Delete it when: never, unless outputFileTracingRoot stops pointing
+  # outside this directory.
   "@radix-ui/react-slot": "1.3.3"
-  picomatch: ">=4.0.4"
-  systeminformation: ">=5.31.0"
-  brace-expansion: "^2.0.3"
-  lodash: ">=4.18.0"
-  markdown-it: ">=14.1.1"
-  ajv: ">=8.18.0"
-  rollup: ">=4.59.0"
-  basic-ftp: ">=5.2.2"
-  undici: ">=8.9.0"
-  yauzl: ">=3.2.1"
-  "ws@7": ">=7.5.11"
-  "ws@8": ">=8.21.0"
-  qs: ">=6.15.2"
-  vite: ">=8.0.16"
-  postcss: ">=8.5.17"
-  esbuild: ">=0.28.1"
-  "js-yaml@3": ">=3.15.1 <4"
-  "js-yaml@4": ">=4.3.1 <5"
+
+  # next@15.5.23 bundles postcss 8.4.31. Four advisories apply to it, the
+  # newest fixed in 8.5.23 (GHSA-fxqj-rqcc-2cmp, GHSA-r28c-9q8g-f849).
+  # Resolves to 8.5.26 (our own direct devDependency) with this in place.
+  # Delete it when: `npm view next@latest dependencies | grep postcss` is
+  # >=8.5.23 and we are on that Next.
+  postcss: ">=8.5.23"
+
+  # next@15.5.23 bundles sharp 0.34.5 (GHSA-f88m-g3jw-g9cj, fixed 0.35.0).
+  # Delete it when: Next's bundled sharp is >=0.35.0.
   sharp: ">=0.35.0"
+
+  # pm2@7.0.3 pins js-yaml 4.3.0 (GHSA-5p4m-2wfm-xmqj, fixed 4.3.1). The
+  # `<5` half is the one exception to "floors, never ceilings" -- it
+  # enforces the js-yaml v5 hold recorded in .github/dependabot.yml (no
+  # default export, dates load as strings), because a bare floor would
+  # resolve straight to v5. The scope is `js-yaml@4` so it cannot touch
+  # gray-matter's js-yaml 3.x, which needs no override.
+  # Delete it when: pm2 ships js-yaml >=4.3.1 AND that hold is lifted.
+  "js-yaml@4": ">=4.3.1 <5"
+
+  # ── Deleted in the 2026-09-03 sweep ──────────────────────────────────
+  # Kept as a record so nobody re-adds one without re-testing. Restated
+  # reasons rot; if you think one is needed again, run the check above.
+  #
+  # Package had left the tree entirely -- nothing depended on it any more:
+  #   markdown-it       ">=14.1.1"
+  #   rollup            ">=4.59.0"   (vite 8 uses rolldown)
+  #   systeminformation ">=5.31.0"
+  #   yauzl             ">=3.2.1"
+  #
+  # Never needed: the parent's range already allowed the patched version,
+  # so `pnpm audit --fix update` moved the stuck lockfile entry and that
+  # was the whole fix. Added and removed the same day, 2026-09-03.
+  #   qs          ">=6.16.0"      union ^6.4.0, url ^6.12.3 -> 6.16.0
+  #   fast-uri@3  ">=3.1.6 <4"    ajv ^3.0.1 -> 3.1.7
+  #   fast-uri@4  ">=4.1.3"       fastify chain ^4.0.0 -> 4.1.4
+  # (fast-uri also shows why scoping matters: it has two live majors, and
+  # an unscoped floor would have dragged ajv's 3.x onto 4.x -- exactly what
+  # the old `ws@7: ">=7.5.11"` entry did before it was deleted.)
+  #
+  # Advisory no longer applied, and the override was forcing a major on its
+  # consumers for nothing:
+  #   brace-expansion "^2.0.3"  a ceiling, not a floor. Pinned minimatch@10
+  #                             three majors back at 2.1.4 when it wants
+  #                             5.0.9. GHSA-v6h2-p8h4-qcjw was fixed in
+  #                             2.0.2, so the reason was long gone.
+  #   picomatch       ">=4.0.4" forced anymatch/micromatch/readdirp from
+  #                             2.3.2 to 4.0.5. ReDoS fixed in 2.3.1.
+  #   undici          ">=8.9.0" forced cheerio + open-graph-scraper from
+  #                             7.29.0 to 8.10.0. 7.x carries no advisory.
+  #   basic-ftp       ">=5.2.2" forced get-uri from 5.3.1 to 6.2.0.
+  #
+  # Already pure no-ops -- the tree resolved at or above the floor unaided,
+  # so deleting them changed nothing:
+  #   lodash    ">=4.18.0"     async@2.6.4 + slate-react give 4.18.1
+  #   ajv       ">=8.18.0"     fastify chain gives 8.20.0 (latest)
+  #   vite      ">=8.0.16"     our own direct devDependency, 8.2.2
+  #   esbuild   ">=0.28.1"     tsx + vite give 0.28.2
+  #   ws@8      ">=8.21.0"     pm2@7.0.3 gives 8.21.0
+  #   ws@7      ">=7.5.11"     no ws 7 in the tree at all, and with no
+  #                            upper bound it resolved to ws 8 anyway
+  #   js-yaml@3 ">=3.15.1 <4"  gray-matter gives 3.15.1
 
 peerDependencyRules:
   # Packages that haven't declared React 19 support (or use malformed semver


### PR DESCRIPTION
## Why Dependabot never opened a PR for these

All 10 open alerts were on `fast-uri` and `qs`, both transitive-only. Dependabot's npm updater fixes a transitive vulnerability by bumping the **parent** to a release that already depends on a patched version — it never does a lockfile-only bump, and it will not write a pnpm override. `ajv@8.20.0` is already latest, and `union`/`url` are stale, so there was nothing for it to bump and the alerts sat open with no PR.

Security updates were enabled and unpaused the whole time; this is structural, not a misconfiguration.

## The fix

Every parent's range already permitted the patched version (`ajv → fast-uri ^3.0.1`, fastify chain `→ ^4.0.0`, `union → qs ^6.4.0`, `url → qs ^6.12.3`). The lockfile was simply **stuck**, because pnpm never re-resolves an existing entry on a plain install.

```
fast-uri  3.1.5 -> 3.1.7,  4.1.2 -> 4.1.4   (8 high)
qs        6.15.3 -> 6.16.0                  (2 moderate)
```

No override was needed for any of them.

## Overrides sweep: 20 entries -> 4

The block had gone stale, so I tested every entry rather than trusting its stated reason — commented the whole block out, re-resolved, and audited the result.

Survivors, all genuine "a parent caps us" cases:

| entry | capped by |
|---|---|
| `postcss: ">=8.5.23"` | next@15.5.23 bundles 8.4.31 |
| `sharp: ">=0.35.0"` | next@15.5.23 bundles 0.34.5 |
| `"js-yaml@4": ">=4.3.1 <5"` | pm2@7.0.3 pins 4.3.0 |
| `"@radix-ui/react-slot"` | not security — the existing outputFileTracingRoot guard |

Removed:

- **`brace-expansion: "^2.0.3"`** — a **ceiling** sitting in a block whose header claimed there were none. It pinned minimatch@10 three majors back at 2.1.4 when it wants 5.0.9; its advisory was fixed in 2.0.2, so the reason was long gone and nobody had recorded the bound.
- **`picomatch`, `undici`, `basic-ftp`** — each forced a major on its consumers (2.3.2→4.0.5, 7.29.0→8.10.0, 5.3.1→6.2.0) for advisories that no longer apply.
- **`lodash`, `ajv`, `vite`, `esbuild`, `ws@7`, `ws@8`, `js-yaml@3`** — already pure no-ops.
- **`markdown-it`, `rollup`, `systeminformation`, `yauzl`** — packages had left the tree entirely.

The header now states the invariant (**a floor is justified only when a parent's range caps us below the fix**), each survivor records who is capping it and a checkable "delete it when" condition, and the deleted entries are kept as a comment so nobody re-adds one without re-testing. Also corrected the postcss floor from `>=8.5.17` to `>=8.5.23` — the old number sat below two of the advisories it was supposed to cover.

## New workflow

`.github/workflows/security-autofix.yml` closes the gap going forward. There is no `dependabot_alert` workflow trigger, so it polls daily at 07:00 UTC. It routes to the same two cases:

- lockfile merely stuck → `pnpm update --depth Infinity` → tests + buildstatic → PR
- a parent caps us → **issue**, because the annotation that entry needs is a judgment call
- bump breaks the build → issue linking the failing run, no PR

⚠️ **Needs a repo secret before it can open PRs:** `SECURITY_AUTOFIX_TOKEN`, a fine-grained PAT scoped to this repo with **Contents: Read and write** and **Pull requests: Read and write** (Metadata: Read is auto-included). Not Issues — those are opened with the default `GITHUB_TOKEN`. The PAT exists so `pr-checks.yml` actually runs on the PRs it opens; `GITHUB_TOKEN`-authored PRs don't trigger other workflows. Until the secret exists the escalation path still works and the PR step will fail loudly.

### One thing worth knowing

I tried `pnpm audit --fix update` as the primitive first. On this tree it reported *"0 vulnerabilities were fixed"* and still ran a broad update — adding packages and bumping `satori: ^0.29.0 → ^0.29.1` in package.json. `pnpm update --depth Infinity <pkgs>` is the correct primitive; the workflow has a `git diff --exit-code` guard that fails the run if that ever stops being true.

## Verification

- `pnpm audit --audit-level=low` clean
- 623 tests pass across 38 files
- `pnpm buildstatic` passes, 109 HTML files
- Reproduced the original 10-alert state from the HEAD lockfile and confirmed the targeted update clears all 10 while leaving package.json byte-identical
- Both node steps in the workflow executed against a real `pnpm audit --json` fixture, not just YAML-linted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated daily and on-demand dependency security checks and fixes.
  * Successful fixes are validated before a pull request is opened; issues are created when additional remediation is required.

* **Maintenance**
  * Updated dependency security rules and minimum supported versions to address known vulnerabilities and keep packages current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->