### PR TITLE
Fix cron jobs and healthchecks that were misconfigured

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -107,6 +107,14 @@ REMOTE_SKIP_API=0
 # NEWSLETTER_ENV_PRODUCTION_PATH=/absolute/path/to/repo/.env.production
 # LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE=./.env.production.newsletter.local
 
+# Private scratch directory for shell scripts and Node tooling. /tmp on the web
+# host is world-readable and shared with hundreds of other accounts, so anything
+# staged there (health-check response bodies, images still carrying the EXIF we
+# are about to strip) is readable by all of them. scripts/load-env.sh exports
+# this as TMPDIR/TMP/TEMP and creates it 0700. Leave unset on dev machines and
+# it falls back to $HOME/include/.tmp when that exists, else the system default.
+SCRIPTS_TMPDIR=
+
 # === Server / cron script logs (healthchecks, api monitor, etc.)
 # One directory; each script writes its own file there (e.g. healthcheck-site.log).
 # Tail line count for trim_log rotation (shared by all scripts).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,20 @@ indefinitely, so anything logged persists until someone notices.
   `api/server.js` already logs one line per request — leaving both on produced a
   351MB log file.
 
+## Temp file rules
+
+The web host is shared: `/tmp` is world-readable and ~318 other accounts live on
+the same machine.
+
+* **Never hardcode `/tmp`** in a script or Node module. Use `mktemp` in shell and
+  `os.tmpdir()` in Node — both follow `TMPDIR`, which `scripts/load-env.sh` points
+  at `~/include/.tmp` (mode 0700) on the servers.
+* For anything sensitive, create a private directory rather than a single file:
+  `mkdtemp` in Node, `mktemp -d` in shell. A predictable name like
+  `/tmp/metadata_temp_<Date.now()><ext>` is both world-readable and guessable —
+  that one staged images that still carried their original EXIF.
+* Always clean up on the error path too, not just on success.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,32 @@
 * Use constant-time comparison for tokens and hashes.
 * Never log secrets, tokens, or PII.
 
+## Logging rules
+
+This is a site for activists. A visitor IP or a subscriber email sitting in a log
+file is a safety problem, not just a compliance one. PM2 keeps app logs on disk
+indefinitely, so anything logged persists until someone notices.
+
+* **Never log an IP address, email address, name, form body, or contact message.**
+  This includes indirect logging: dumping a request body, an API response body, or
+  a caught `error` object that carries the payload. Both real leaks we have had
+  came from logging a whole object rather than a chosen field — `console.log('...',
+  { payload })` and `console.log('...', { data: parsedData })` in `lib/listmonk.js`,
+  which wrote ~1,300 subscriber emails to `include/.pm2/logs/`.
+* **Log chosen fields, never whole objects.** `{ status, endpoint }`, not
+  `{ status, data }`. If you need to log a caught error, log `error.message`, not
+  `error`.
+* Reviewing a diff: any new `console.log` / `console.error` / `log.info` in `api/`
+  or `lib/` whose argument is a bare object or an `error` is the thing to question.
+  Ask "what is actually inside this at runtime?" — a Listmonk or Resend response
+  contains the user's email even when the call succeeded.
+* IP addresses may be used in memory (rate-limit keys, hashing) but must never
+  reach a log line. `api/server.js` reads `x-forwarded-for` for rate limiting only.
+* Keep log volume bounded. Fastify's default per-request logging is disabled in
+  `api/start.js` (`disableRequestLogging`) because the `onResponse` hook in
+  `api/server.js` already logs one line per request — leaving both on produced a
+  351MB log file.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/api/start.js
+++ b/api/start.js
@@ -10,7 +10,15 @@ dotenv.config({
 });
 
 // Instantiate Fastify with the options from server.js (logger is not in server.js so CLI pretty-logs still work)
-const server = Fastify({ logger: true, ...(app.options || {}) });
+// disableRequestLogging: Fastify's default logger writes an "incoming request"
+// and a "request completed" line for every call. The onResponse hook in
+// server.js already logs one concise line per request, so the built-in pair was
+// pure duplication — 1.47M of the 1.8M lines in a 351MB log.
+const server = Fastify({
+  logger: true,
+  disableRequestLogging: true,
+  ...(app.options || {}),
+});
 
 // Register your application as a normal plugin
 server.register(app);

--- a/lib/listmonk.js
+++ b/lib/listmonk.js
@@ -3,6 +3,22 @@ const https = require('https');
 const url = require('url');
 dotenv.config();
 
+// Subscriber email addresses are PII and this client's output is captured by PM2
+// into include/.pm2/logs/ac-api-out.log, which is long-lived and on disk. Log
+// what is useful for debugging a delivery problem — status, list, subscriber id —
+// and never the address itself. See __tests__/listmonk-log-redaction.test.js.
+function redactSubscriberForLog(value) {
+  if (!value || typeof value !== 'object') return value;
+  const { email, name, attribs, ...rest } = value;
+  const redacted = { ...rest };
+  if (email !== undefined) redacted.email = '[REDACTED]';
+  if (name !== undefined) redacted.name = '[REDACTED]';
+  if (attribs !== undefined) redacted.attribs = '[REDACTED]';
+  // Listmonk nests the subscriber one or two levels deep under `data`.
+  if (rest.data !== undefined) redacted.data = redactSubscriberForLog(rest.data);
+  return redacted;
+}
+
 class ListmonkClient {
   constructor(config = {}) {
     this.baseUrl = config.baseUrl || process.env.LISTMONK_API_URL;
@@ -67,11 +83,7 @@ class ListmonkClient {
 
     console.log('Attempting to add subscriber:', {
       endpoint: parsedUrl.toString(),
-      payload,
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': '[REDACTED]',
-      }
+      lists: subscriberLists,
     });
 
     return new Promise((resolve, reject) => {
@@ -93,10 +105,11 @@ class ListmonkClient {
         res.on('end', () => {
           try {
             const parsedData = JSON.parse(data);
+            // Never log the response body: it echoes back the subscriber's
+            // email and name. Status is all that is useful here.
             console.log('Listmonk API response:', {
               status: res.statusCode,
               ok: res.statusCode >= 200 && res.statusCode < 300,
-              data: parsedData
             });
 
             if (res.statusCode >= 200 && res.statusCode < 300 || res.statusCode === 409) {
@@ -108,7 +121,7 @@ class ListmonkClient {
             } else {
               console.error('Listmonk API error:', {
                 status: res.statusCode,
-                data: parsedData,
+                data: redactSubscriberForLog(parsedData),
                 endpoint: parsedUrl.toString()
               });
               const errMsg = process.env.NODE_ENV === 'production'
@@ -144,3 +157,4 @@ class ListmonkClient {
 }
 
 module.exports = ListmonkClient;
+module.exports.redactSubscriberForLog = redactSubscriberForLog;

--- a/lib/metadata-library.cjs
+++ b/lib/metadata-library.cjs
@@ -1,6 +1,7 @@
 const fs = require('fs/promises')
 const fsSync = require('fs')
 const path = require('path')
+const os = require('os')
 const { execFile } = require('child_process')
 
 // Try to load sharp, but handle gracefully if it fails
@@ -85,10 +86,17 @@ class MetadataStripper {
           console.log(`    ⚠️ Sharp failed to remove XMP, using exiftool fallback`)
         }
 
-        // Write to temp file for exiftool processing
+        // Write to temp file for exiftool processing.
+        //
+        // This buffer still carries the XMP that Sharp could not remove, so it is
+        // exactly the data we are trying to destroy — on a shared host it must not
+        // land in world-readable /tmp under a guessable name. mkdtemp creates a
+        // 0700 directory with a random suffix inside os.tmpdir(), which honours
+        // TMPDIR (set to ~/include/.tmp on the server by scripts/load-env.sh).
         const fileExt = originalFilePath ? path.extname(originalFilePath) : '.png'
-        const tempPath = '/tmp/metadata_temp_' + Date.now() + fileExt
-        await fs.writeFile(tempPath, strippedBuffer)
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'metadata-'))
+        const tempPath = path.join(tempDir, `strip${fileExt}`)
+        await fs.writeFile(tempPath, strippedBuffer, { mode: 0o600 })
 
         try {
           // Use exiftool to remove all metadata
@@ -97,8 +105,8 @@ class MetadataStripper {
           // Read the cleaned file back
           const cleanedBuffer = await fs.readFile(tempPath)
 
-          // Clean up temp file
-          await fs.unlink(tempPath)
+          // Clean up temp dir
+          await fs.rm(tempDir, { recursive: true, force: true })
 
           // Verify XMP was removed (only if Sharp is available)
           const finalMetadata = sharp ? await sharp(cleanedBuffer).metadata() : null
@@ -112,9 +120,10 @@ class MetadataStripper {
 
           return cleanedBuffer
         } catch (exiftoolError) {
-          // Clean up temp file on error
+          // Clean up temp dir on error: leaving it behind would strand an image
+          // that still has its original metadata.
           try {
-            await fs.unlink(tempPath)
+            await fs.rm(tempDir, { recursive: true, force: true })
           } catch { }
           throw new Error(`Both Sharp and exiftool failed to remove XMP metadata: ${exiftoolError.message}`)
         }

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -27,19 +27,37 @@ source "$SCRIPT_DIR/log.sh"
 
 init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "cleanup-tmp.log" "$(resolve_server_log_lines_keep)"
 
-TMP_DIR="${CLEANUP_TMP_DIR:-${TMPDIR:-$HOME/.tmp}}"
-TMP_DIR="${TMP_DIR%/}"
 MIN_AGE="${CLEANUP_TMP_MIN_AGE:-1440}"
 DRY_RUN="${CLEANUP_TMP_DRY_RUN:-0}"
 
-# Only ever prune a real, non-root directory we own. A misconfigured
-# CLEANUP_TMP_DIR should abort, not walk someone's home or /.
-if [[ -z "$TMP_DIR" || "$TMP_DIR" == "/" || "$TMP_DIR" == "$HOME" ]]; then
-  log_echo "ERROR: refusing to prune TMP_DIR='$TMP_DIR'"
-  exit 1
+# Prune the active temp dir (load-env.sh points TMPDIR at ~/include/.tmp on the
+# servers) *and* the legacy ~/.tmp the scheduler still sets for jobs that do not
+# source load-env.sh. Without the second entry the 215MB of pre-pnpm yarn dirs
+# sitting there would never be collected again.
+CANDIDATE_DIRS=()
+if [[ -n "${CLEANUP_TMP_DIR:-}" ]]; then
+  CANDIDATE_DIRS+=("$CLEANUP_TMP_DIR")
+else
+  [[ -n "${TMPDIR:-}" ]] && CANDIDATE_DIRS+=("$TMPDIR")
+  CANDIDATE_DIRS+=("$HOME/include/.tmp" "$HOME/.tmp")
 fi
-if [[ ! -d "$TMP_DIR" ]]; then
-  log_echo "Nothing to do: $TMP_DIR does not exist"
+
+# Only ever prune a real, non-root directory we own, and never the same one
+# twice. A misconfigured path should abort, not walk someone's home or /.
+TMP_DIRS=()
+for d in "${CANDIDATE_DIRS[@]}"; do
+  d="${d%/}"
+  [[ -z "$d" || "$d" == "/" || "$d" == "$HOME" ]] && continue
+  [[ -d "$d" ]] || continue
+  seen=0
+  for existing in ${TMP_DIRS[@]+"${TMP_DIRS[@]}"}; do
+    [[ "$existing" == "$d" ]] && seen=1 && break
+  done
+  (( seen )) || TMP_DIRS+=("$d")
+done
+
+if (( ${#TMP_DIRS[@]} == 0 )); then
+  log_echo "Nothing to do: no prunable temp directory found"
   exit 0
 fi
 
@@ -58,22 +76,27 @@ fi
 # node rebuilds, not orphaned working directories.
 PATTERNS=('yarn--*' 'pnpm-*' 'npm-*' 'tmp.*')
 
-log_echo "=== cleanup-tmp started dir=$TMP_DIR min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
-before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+log_echo "=== cleanup-tmp started dirs='${TMP_DIRS[*]}' min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
 
-removed=0
-for pattern in "${PATTERNS[@]}"; do
-  # -mindepth 1 keeps $TMP_DIR itself out of the match set.
-  while IFS= read -r -d '' entry; do
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log_echo "would remove: $entry"
-    else
-      rm -rf -- "$entry"
-    fi
-    removed=$((removed + 1))
-  done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+total_removed=0
+for TMP_DIR in "${TMP_DIRS[@]}"; do
+  before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+  removed=0
+  for pattern in "${PATTERNS[@]}"; do
+    # -mindepth 1 keeps $TMP_DIR itself out of the match set.
+    while IFS= read -r -d '' entry; do
+      if [[ "$DRY_RUN" == "1" ]]; then
+        log_echo "would remove: $entry"
+      else
+        rm -rf -- "$entry"
+      fi
+      removed=$((removed + 1))
+    done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+  done
+  after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+  log_echo "$TMP_DIR: removed=$removed size ${before_size:-?} -> ${after_size:-?}"
+  total_removed=$((total_removed + removed))
 done
 
-after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
-log_echo "=== cleanup-tmp done removed=$removed size ${before_size:-?} -> ${after_size:-?} ==="
+log_echo "=== cleanup-tmp done removed=$total_removed across ${#TMP_DIRS[@]} dir(s) ==="
 trim_log

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Prune stale temp directories left behind by package managers and build tooling.
+#
+# Replaces two control-panel jobs that pointed at /tmp with a malformed
+# `find ... -exec -delete`. Both were also looking in the wrong place: the
+# scheduler sets TMPDIR to ~/.tmp, so nothing lands in /tmp any more. By the time
+# this script was written ~/.tmp held 439 orphaned `yarn--*` directories going
+# back to 2024 (215MB), none of them newer than the pnpm migration.
+#
+# Scheduler example (daily):
+#   /absolute/path/to/repo/scripts/cleanup-tmp.sh
+#
+# Env vars:
+#   CLEANUP_TMP_DIR      — directory to prune (default: $TMPDIR, else $HOME/.tmp)
+#   CLEANUP_TMP_MIN_AGE  — minutes; only entries older than this go (default: 1440)
+#   CLEANUP_TMP_DRY_RUN  — 1 to list what would be removed without deleting
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "cleanup-tmp.log" "$(resolve_server_log_lines_keep)"
+
+TMP_DIR="${CLEANUP_TMP_DIR:-${TMPDIR:-$HOME/.tmp}}"
+TMP_DIR="${TMP_DIR%/}"
+MIN_AGE="${CLEANUP_TMP_MIN_AGE:-1440}"
+DRY_RUN="${CLEANUP_TMP_DRY_RUN:-0}"
+
+# Only ever prune a real, non-root directory we own. A misconfigured
+# CLEANUP_TMP_DIR should abort, not walk someone's home or /.
+if [[ -z "$TMP_DIR" || "$TMP_DIR" == "/" || "$TMP_DIR" == "$HOME" ]]; then
+  log_echo "ERROR: refusing to prune TMP_DIR='$TMP_DIR'"
+  exit 1
+fi
+if [[ ! -d "$TMP_DIR" ]]; then
+  log_echo "Nothing to do: $TMP_DIR does not exist"
+  exit 0
+fi
+
+# Leftovers from yarn (pre-pnpm), pnpm, npm, and mktemp. Anything not matching
+# these stays put — this runs unattended and should not guess. Deliberately
+# excludes v8-compile-cache-* and node-compile-cache: those are live caches that
+# node rebuilds, not orphaned working directories.
+PATTERNS=('yarn--*' 'pnpm-*' 'npm-*' 'tmp.*')
+
+log_echo "=== cleanup-tmp started dir=$TMP_DIR min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
+before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+
+removed=0
+for pattern in "${PATTERNS[@]}"; do
+  # -mindepth 1 keeps $TMP_DIR itself out of the match set.
+  while IFS= read -r -d '' entry; do
+    if [[ "$DRY_RUN" == "1" ]]; then
+      log_echo "would remove: $entry"
+    else
+      rm -rf -- "$entry"
+    fi
+    removed=$((removed + 1))
+  done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+done
+
+after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+log_echo "=== cleanup-tmp done removed=$removed size ${before_size:-?} -> ${after_size:-?} ==="
+trim_log

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -43,6 +43,15 @@ if [[ ! -d "$TMP_DIR" ]]; then
   exit 0
 fi
 
+# A non-numeric age makes find reject the -mmin argument, which (with stderr
+# discarded) would silently prune nothing forever. A too-small one is worse: it
+# would delete the working directories of builds that are still running. Require
+# an integer, floor at an hour.
+if [[ ! "$MIN_AGE" =~ ^[0-9]+$ ]] || (( MIN_AGE < 60 )); then
+  log_echo "ERROR: CLEANUP_TMP_MIN_AGE must be an integer >= 60 minutes (got '$MIN_AGE')"
+  exit 1
+fi
+
 # Leftovers from yarn (pre-pnpm), pnpm, npm, and mktemp. Anything not matching
 # these stays put — this runs unattended and should not guess. Deliberately
 # excludes v8-compile-cache-* and node-compile-cache: those are live caches that

--- a/scripts/deploy-secrets.sh
+++ b/scripts/deploy-secrets.sh
@@ -48,6 +48,11 @@ fi
 
 echo "===> [site] Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."
 rsync -avz "$LOCAL_ENV_PRODUCTION_FILE" "$FTP_USER@$FTP_HOST:$ENV_PRODUCTION_PATH"
+# rsync -a implies -p, so the remote file inherits the *local* file's mode: a 644
+# copy here would silently re-widen the server's env file on every deploy. This
+# holds API keys and IP_HASH_SALT, so pin it owner-only regardless of local mode.
+# The newsletter branch below does the same.
+ssh "$FTP_USER@$FTP_HOST" "chmod 600 '$ENV_PRODUCTION_PATH'"
 
 echo "===> [site] Syncing public/webhooks/ to $FTP_HOST:$FTP_DIR/webhooks/ ..."
 # Exclude webhook-secrets.local.php from this pass: with --delete, an absent local copy would

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
 # API health monitor for PM2 app.
-# - Checks whether APP_NAME is online in PM2
-# - Attempts restart/start if not online
-# - Sends Healthchecks ping on success
+# - Verifies APP_NAME is online in PM2 *and* that the API actually answers HTTP
+# - Attempts restart/start if not healthy
+# - Sends Healthchecks ping only when the HTTP probe succeeds
 #
-# Cron example:
-# */5 * * * * /absolute/path/to/repo/scripts/api-health-monitor.sh >/dev/null 2>&1
+# Scheduler example:
+# */5 * * * * /absolute/path/to/repo/scripts/healthcheck-api.sh >/dev/null 2>&1
 #
 # Logs: LOG_DIR (or <repo>/logs); trim lines from LOG_LINES_KEEP (or 500).
 #
@@ -32,6 +32,17 @@ APP_NAME="${API_APP_NAME:-ac-api}"
 API_HEALTHCHECK_PING_URL="${API_HEALTHCHECK_PING_URL:-}"
 PM2_HOME="${API_HEALTH_PM2_HOME:-$PROJECT_DIR/.pm2}"
 export PM2_HOME
+
+# HTTP liveness probe. Hits the app directly on loopback so this check reports on
+# the API process itself; healthcheck-site.sh covers the public path through the
+# web server. Routes are registered under the /api-server prefix (api/server.js).
+API_PORT="${API_PORT:-4321}"
+API_HEALTH_URL="${API_HEALTH_URL:-http://127.0.0.1:${API_PORT}/api-server/hello}"
+API_HEALTH_HTTP_ATTEMPTS="${API_HEALTH_HTTP_ATTEMPTS:-3}"
+API_HEALTH_HTTP_RETRY_SLEEP="${API_HEALTH_HTTP_RETRY_SLEEP:-3}"
+
+# Start PM2 inside its own transient systemd scope. Set to 0 to always start directly.
+API_HEALTH_USE_SYSTEMD_RUN="${API_HEALTH_USE_SYSTEMD_RUN:-1}"
 
 # Shared nvm-pnpm lib (scripts/lib/nvm-pnpm.sh): prefer NVM_PNPM_* from .env;
 # API_HEALTH_* nvm vars are legacy aliases only.
@@ -70,11 +81,67 @@ hc_ok() {
   fi
 }
 
+# True when the API answers 2xx. PM2 reporting "online" is not proof the app is
+# serving: the process can be up, wedged, or about to be reaped.
+api_http_ok() {
+  local attempts="${1:-1}"
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if curl -fsS --max-time 10 -o /dev/null "$API_HEALTH_URL"; then
+      return 0
+    fi
+    if ((i < attempts)); then
+      sleep "$API_HEALTH_HTTP_RETRY_SLEEP"
+    fi
+  done
+  return 1
+}
+
+# The host schedules these jobs as Type=oneshot systemd user services. systemd's
+# default KillMode=control-group reaps every process left in the unit cgroup the
+# moment this script exits. PM2's CLI silently auto-spawns its God daemon on *any*
+# command (`pm2 status` included), so a daemon spawned from here inherits the unit
+# cgroup and dies seconds later — that is why the API used to come up for ~7s and
+# vanish every 5 minutes.
+#
+# So the very first pm2 call must happen inside its own transient scope: if a
+# daemon needs spawning it lands in that separate cgroup and outlives this unit.
+# If one is already running, ping simply connects to it and the empty scope is
+# garbage-collected by --collect. Inspect with:
+#   systemctl --user list-units 'ac-api-pm2-*.scope'
+ensure_pm2_daemon() {
+  if [[ "$API_HEALTH_USE_SYSTEMD_RUN" != "1" ]] || ! command -v systemd-run >/dev/null 2>&1; then
+    echo "systemd-run unavailable; PM2 daemon will start in the caller's cgroup"
+    return 0
+  fi
+
+  local scope_name="ac-api-pm2-$$-$(date +%s)"
+  # --scope inherits this shell's exported environment, so the child only needs
+  # to re-source the nvm/pnpm helper (shell functions do not survive exec).
+  if systemd-run --user --scope --quiet --collect --unit="$scope_name" -- \
+    bash -c 'set -euo pipefail
+cd "$NVM_PNPM_PROJECT_DIR"
+source "$NVM_PNPM_PROJECT_DIR/scripts/lib/nvm-pnpm.sh"
+nvm_pnpm_init
+nvm_pnpm exec pm2 ping'; then
+    echo "PM2 daemon reachable via scope $scope_name.scope"
+    return 0
+  fi
+
+  echo "WARN: systemd-run scope failed; PM2 daemon may not survive this unit"
+  return 0
+}
+
+start_api() {
+  nvm_pnpm api:start
+}
+
 log_echo "=== API Health Monitor Started ==="
 log_echo "Project: $PROJECT_DIR"
 log_echo "App: $APP_NAME"
 log_echo "Log file: $LOG_FILE"
 log_echo "PM2_HOME: $PM2_HOME"
+log_echo "Probe: $API_HEALTH_URL"
 
 if [[ ! -d "$PROJECT_DIR" ]]; then
   msg="api-health failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ"))\nproject_dir_missing=$PROJECT_DIR\npm2_home=$PM2_HOME"
@@ -98,45 +165,67 @@ fi
 
 if [[ -n "${NVM_PNPM_RESOLVED_VERSION:-}" ]]; then
   log_echo "Node: $(nvm exec "$NVM_PNPM_RESOLVED_VERSION" node -v) (nvm exec $NVM_PNPM_RESOLVED_VERSION)"
-  log_echo "pnpm: $(nvm exec "$NVM_PNPM_RESOLVED_VERSION" command -v pnpm)"
 else
   log_echo "pnpm: $(command -v pnpm)"
 fi
 
+# Must run before any other pm2 command (see ensure_pm2_daemon above).
+ENSURE_LOG="$(mktemp)"
+ensure_pm2_daemon >"$ENSURE_LOG" 2>&1 || true
+cat "$ENSURE_LOG" >> "$LOG_FILE"
+rm -f "$ENSURE_LOG"
+
 PM2_OUTPUT="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
 echo "$PM2_OUTPUT" >> "$LOG_FILE"
 
+PM2_ONLINE=0
 if echo "$PM2_OUTPUT" | grep -q "online"; then
-  log_echo "OK: $APP_NAME is online"
+  PM2_ONLINE=1
+fi
+
+HTTP_OK=0
+if api_http_ok 1; then
+  HTTP_OK=1
+fi
+
+if [[ "$PM2_ONLINE" -eq 1 ]] && [[ "$HTTP_OK" -eq 1 ]]; then
+  log_echo "OK: $APP_NAME is online and answering"
   SERVICE_ONLINE=1
 else
-  log_echo "WARN: $APP_NAME is not online; attempting start/restart"
-  START_OUTPUT="$(nvm_pnpm api:start 2>&1 || true)"
-  echo "$START_OUTPUT" >> "$LOG_FILE"
+  log_echo "WARN: unhealthy (pm2_online=$PM2_ONLINE http_ok=$HTTP_OK); attempting start/restart"
+  # Write to a file rather than a command substitution: a detached PM2 daemon can
+  # inherit the pipe and make $( ) block until the daemon itself exits.
+  START_LOG="$(mktemp)"
+  start_api >"$START_LOG" 2>&1 || true
+  cat "$START_LOG" >> "$LOG_FILE"
+  rm -f "$START_LOG"
+
   sleep 5
   RECHECK_OUTPUT="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
   echo "$RECHECK_OUTPUT" >> "$LOG_FILE"
 
-  if echo "$RECHECK_OUTPUT" | grep -q "online"; then
-    log_echo "OK: $APP_NAME is online after restart"
+  # Gate recovery on the HTTP probe, not on PM2's status text.
+  if api_http_ok "$API_HEALTH_HTTP_ATTEMPTS"; then
+    log_echo "OK: $APP_NAME is answering after restart"
     SERVICE_ONLINE=1
   else
-    log_echo "ERROR: $APP_NAME failed to become online"
+    log_echo "ERROR: $APP_NAME still not answering $API_HEALTH_URL after restart"
     SERVICE_ONLINE=0
   fi
 fi
 
 if [[ "$SERVICE_ONLINE" -eq 1 ]]; then
-  hc_ok "api-health ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") app=$APP_NAME"
+  hc_ok "api-health ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") app=$APP_NAME url=$API_HEALTH_URL"
   log_echo "OK: API health ping sent"
 else
   body=$(
     printf "api-health failed (%s)\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-    printf "app=%s\nproject_dir=%s\npm2_home=%s\n" "$APP_NAME" "$PROJECT_DIR" "$PM2_HOME"
-    printf "pm2_status_snippet=%s\n" "$(echo "$PM2_OUTPUT" | tr '\n' ' ' | head -c 400)"
+    printf "app=%s\nproject_dir=%s\npm2_home=%s\nprobe_url=%s\n" "$APP_NAME" "$PROJECT_DIR" "$PM2_HOME" "$API_HEALTH_URL"
+    printf "pm2_online=%s http_ok_before_restart=%s\n" "$PM2_ONLINE" "$HTTP_OK"
+    printf "pm2_status_snippet=%s\n" "$(echo "${RECHECK_OUTPUT:-$PM2_OUTPUT}" | tr '\n' ' ' | head -c 400)"
   )
   hc_fail "$body"
-  log_echo "WARN: Service not online; sent fail ping"
+  log_echo "WARN: Service not answering; sent fail ping"
   exit 1
 fi
 

--- a/scripts/healthcheck-canary.mjs
+++ b/scripts/healthcheck-canary.mjs
@@ -36,8 +36,17 @@ if (!PING_URL) {
   process.exit(2);
 }
 
+// A Healthchecks ping URL is a bearer credential: anyone holding it can forge
+// OK pings and silence the check. This script's output is redirected to
+// include/logs/healthcheck-canary.log, so logging the raw URL wrote the UUID to
+// disk in cleartext. Log only the endpoint being pinged.
+function pingLabel(endpoint) {
+  return `canary ping${endpoint ? ` /${endpoint}` : ''}`;
+}
+
 async function ping(endpoint, body) {
   const url = endpoint ? `${PING_URL}/${endpoint}` : PING_URL;
+  const label = pingLabel(endpoint);
   try {
     const res = await fetch(url, {
       method: 'POST',
@@ -46,13 +55,13 @@ async function ping(endpoint, body) {
       signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) {
-      console.error(`Ping to ${url} returned ${res.status} ${res.statusText}`);
-       return false;
-     }
-     console.log(`Pinged ${url}`);
-     return true;
+      console.error(`${label} returned ${res.status} ${res.statusText}`);
+      return false;
+    }
+    console.log(`${label} ok`);
+    return true;
   } catch (err) {
-    console.error(`Ping to ${url} failed: ${err.message}`);
+    console.error(`${label} failed: ${err.message}`);
     return false;
   }
 }

--- a/scripts/healthcheck-domain.sh
+++ b/scripts/healthcheck-domain.sh
@@ -57,8 +57,11 @@ if command -v whois >/dev/null 2>&1; then
 fi
 
 # 2) Fallback to RDAP over HTTPS (no whois binary/sudo required).
+# rdap.org is a bootstrap/redirect service: it answers 302 pointing at the TLD's
+# authoritative server (.org -> rdap.publicinterestregistry.org), so -L is required.
+# Without it curl returns an empty body and the check fails as expiry_not_found.
 if [[ -z "$expiry_raw" ]]; then
-  rdap_json="$(curl -fsS --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
+  rdap_json="$(curl -fsSL --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
   if [[ -n "$rdap_json" ]]; then
     one_line_json="$(echo "$rdap_json" | tr -d '\n' | tr -d '\r')"
     # Common case: eventAction then eventDate in same event object.

--- a/scripts/healthcheck-domain.sh
+++ b/scripts/healthcheck-domain.sh
@@ -60,8 +60,14 @@ fi
 # rdap.org is a bootstrap/redirect service: it answers 302 pointing at the TLD's
 # authoritative server (.org -> rdap.publicinterestregistry.org), so -L is required.
 # Without it curl returns an empty body and the check fails as expiry_not_found.
+#
+# -L means a third party now chooses where this request lands, so constrain it:
+# --proto-redir =https blocks a downgrade to http or a jump to another scheme,
+# and --max-redirs caps the chain (curl's default is 50). Without these a hijacked
+# rdap.org could point the check at an internal address and get a slice of the
+# response echoed into the could_not_parse_expiry ping body below.
 if [[ -z "$expiry_raw" ]]; then
-  rdap_json="$(curl -fsSL --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
+  rdap_json="$(curl -fsSL --proto-redir =https --max-redirs 3 --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
   if [[ -n "$rdap_json" ]]; then
     one_line_json="$(echo "$rdap_json" | tr -d '\n' | tr -d '\r')"
     # Common case: eventAction then eventDate in same event object.

--- a/scripts/healthcheck-site.sh
+++ b/scripts/healthcheck-site.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
-# Cron-driven health check for static site + API.
+# Scheduled health check for the static site.
 # If all checks pass, ping Healthchecks.io.
+#
+# Deliberately does NOT probe the API: an API outage used to fail this check and
+# fire a misleading "main site down" alert. scripts/healthcheck-api.sh owns the
+# API and probes it over HTTP.
 #
 # Setup example:
 #   export HEALTHCHECK_PING_URL="https://hc-ping.com/your-uuid"
@@ -122,11 +126,6 @@ fi
 # News index should resolve.
 if ! curl -fsS --max-time 15 "$SITE_URL/news/" >/dev/null; then
   errors+=("news: curl failed ($SITE_URL/news/)")
-fi
-
-# API liveness endpoint should resolve.
-if ! curl -fsS --max-time 15 "$SITE_URL/api-server/hello" >/dev/null; then
-  errors+=("api: curl failed ($SITE_URL/api-server/hello)")
 fi
 
 if (( ${#errors[@]} > 0 )); then

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -28,10 +28,47 @@ load_env_file() {
   set +a
 }
 
+# ---------------------------------------------------------------------------
+# Temp directory
+# ---------------------------------------------------------------------------
+# The web host is shared: /tmp is world-readable and 318 other accounts live on
+# the same box. Anything these scripts stage there — a health-check response
+# body, an image still carrying the EXIF we are about to strip — is readable by
+# all of them. Point TMPDIR at a private directory instead, which mktemp,
+# os.tmpdir() and most tooling follow automatically.
+#
+# Resolution order:
+#   1. SCRIPTS_TMPDIR, if set (put it in .env.production to be explicit)
+#   2. $HOME/include/.tmp, if it exists — the convention on the servers
+#   3. otherwise leave TMPDIR alone, so dev machines keep their own default
+#
+# Called from every exit path below, including the ones that return early: this
+# has to run whether or not an env file was found, and SCRIPTS_TMPDIR may itself
+# come from the file that was just sourced.
+apply_scripts_tmpdir() {
+  local dir="${SCRIPTS_TMPDIR:-}"
+  if [[ -z "$dir" && -d "$HOME/include/.tmp" ]]; then
+    dir="$HOME/include/.tmp"
+  fi
+  [[ -n "$dir" ]] || return 0
+
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "warning: could not create temp dir $dir; leaving TMPDIR unchanged" >&2
+    return 0
+  fi
+  # 700: the whole point is that other tenants cannot read what lands here.
+  chmod 700 "$dir" 2>/dev/null || true
+  export TMPDIR="$dir"
+  # Some tooling reads TMP/TEMP rather than TMPDIR; keep all three in step.
+  export TMP="$dir"
+  export TEMP="$dir"
+}
+
 if [[ -n "${ENV_FILE:-}" ]]; then
   if [[ -r "$ENV_FILE" ]]; then
     load_env_file "$ENV_FILE"
     export LOADED_ENV_FILE="$ENV_FILE"
+    apply_scripts_tmpdir
     return 0
   fi
   echo "ENV_FILE is set but unreadable: $ENV_FILE" >&2
@@ -42,9 +79,11 @@ for candidate in "$ROOT_DIR/.env.production" "$ROOT_DIR/.env.local" "$ROOT_DIR/.
   if [[ -r "$candidate" ]]; then
     load_env_file "$candidate"
     export LOADED_ENV_FILE="$candidate"
+    apply_scripts_tmpdir
     return 0
   fi
 done
 
 # Not an error: scripts can still run with environment provided externally.
+apply_scripts_tmpdir
 return 0

--- a/scripts/rotate-api-logs.sh
+++ b/scripts/rotate-api-logs.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Trim the PM2 app logs to a short retention window.
+#
+# PM2 does not rotate logs on its own, so include/.pm2/logs grew to 640MB across
+# two files, the oldest entries dating to 2025. Anything logged lives forever
+# until someone notices — which is how ~1,300 subscriber emails ended up sitting
+# on disk for a year. Keep the window short so a future logging mistake has a
+# bounded blast radius.
+#
+# Truncates in place with `: >` rather than deleting: PM2 holds the file open, so
+# unlinking it would leave the daemon writing to an invisible inode until restart.
+#
+# Scheduler example (daily):
+#   /absolute/path/to/repo/scripts/rotate-api-logs.sh
+#
+# Env vars:
+#   API_LOG_DIR          — PM2 log dir (default: $API_HEALTH_PM2_HOME/logs)
+#   API_LOG_RETAIN_HOURS — keep entries newer than this (default: 24)
+#   API_LOG_MAX_BYTES    — truncate outright above this size (default: 52428800)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "rotate-api-logs.log" "$(resolve_server_log_lines_keep)"
+
+PM2_HOME_DIR="${API_HEALTH_PM2_HOME:-$PROJECT_DIR/.pm2}"
+LOG_DIR_TARGET="${API_LOG_DIR:-$PM2_HOME_DIR/logs}"
+RETAIN_HOURS="${API_LOG_RETAIN_HOURS:-24}"
+MAX_BYTES="${API_LOG_MAX_BYTES:-52428800}"
+
+if [[ ! "$RETAIN_HOURS" =~ ^[0-9]+$ ]] || (( RETAIN_HOURS < 1 )); then
+  log_echo "ERROR: API_LOG_RETAIN_HOURS must be an integer >= 1 (got '$RETAIN_HOURS')"
+  exit 1
+fi
+if [[ ! -d "$LOG_DIR_TARGET" ]]; then
+  log_echo "Nothing to do: $LOG_DIR_TARGET does not exist"
+  exit 0
+fi
+
+cutoff_ms=$(( ($(date +%s) - RETAIN_HOURS * 3600) * 1000 ))
+log_echo "=== rotate-api-logs dir=$LOG_DIR_TARGET retain_hours=$RETAIN_HOURS ==="
+
+shopt -s nullglob
+for f in "$LOG_DIR_TARGET"/*.log; do
+  size=$(wc -c <"$f" | tr -d ' ')
+
+  # Oversized files are truncated outright rather than filtered: parsing hundreds
+  # of MB line by line costs more than the history is worth.
+  if (( size > MAX_BYTES )); then
+    : >"$f"
+    log_echo "truncated (was $size bytes, over ${MAX_BYTES}): $(basename "$f")"
+    continue
+  fi
+
+  # Keep pino JSON lines newer than the cutoff. Lines without a parseable "time"
+  # (plain console.log output) are dropped, since they cannot be dated and are
+  # the noisiest part of the file.
+  kept="$(mktemp)"
+  awk -v cutoff="$cutoff_ms" '
+    match($0, /"time":[0-9]+/) {
+      t = substr($0, RSTART + 7, RLENGTH - 7) + 0
+      if (t >= cutoff) print
+    }
+  ' "$f" >"$kept" 2>/dev/null || true
+
+  new_size=$(wc -c <"$kept" | tr -d ' ')
+  cat "$kept" >"$f"
+  rm -f "$kept"
+  log_echo "trimmed $(basename "$f"): $size -> $new_size bytes"
+done
+
+log_echo "=== rotate-api-logs done ==="
+trim_log


### PR DESCRIPTION
The host migrated scheduled jobs from cron to systemd user units. Each job
now runs as a Type=oneshot service, and systemd's default
KillMode=control-group reaps everything left in the unit cgroup when the
script exits.

PM2's CLI silently auto-spawns its God daemon on any command, `pm2 status`
included. So healthcheck-api.sh spawned the daemon into its own unit cgroup,
started ac-api under it, pinged healthchecks.io OK, exited, and systemd
immediately SIGTERM'd the lot. The API was up roughly 7 seconds out of every
300 and served 503s the rest of the time.

Two fixes:

- ensure_pm2_daemon() makes the *first* pm2 call happen inside a transient
  `systemd-run --user --scope`, so a newly spawned daemon lands in a separate
  cgroup that outlives the oneshot unit. Ordering matters: any earlier pm2
  invocation would spawn the daemon in the doomed cgroup first. Falls back to
  a direct start where systemd-run is unavailable.

- The healthcheck now probes the API over HTTP and only reports success on a
  real 2xx. It previously trusted `pm2 status` containing "online", which
  reported green for a process that was killed six seconds later. Recovery
  after a restart is gated on the HTTP probe rather than PM2's status text.

Start output goes to a temp file rather than a command substitution, since a
detached daemon inheriting the pipe can block $( ) until the daemon exits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated cleanup for stale temporary directories, with configurable age limits and dry-run support.
  - Expanded API health monitoring to include HTTP endpoint checks alongside process status.
- **Bug Fixes**
  - Improved recovery handling when the API or process manager is unavailable.
  - Production environment files are now restricted to owner-only access after deployment.
  - Health-check redirects now safely support HTTPS destinations.
  - Sensitive health-check URLs are no longer written to logs.
  - Static site checks no longer duplicate API monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->