### PR TITLE
Make the listmonk health check verify a real subscribe round trip, and stop systemd reaping the service

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -168,8 +168,10 @@ LISTMONK_HEALTHCHECK_PING_URL=https://hc-ping.com/your-listmonk-check-uuid
 # LISTMONK_SUBSCRIBE_TEST_EMAIL=healthcheck@example.com
 # LISTMONK_SUBSCRIBE_TEST_NAME=Healthcheck Monitor
 # LISTMONK_ROUNDTRIP_TIMEOUT=20
-# Set to 0 only if the host has no systemd user session (see launch-listmonk.sh).
-# LISTMONK_PM2_SCOPE=1
+# Service backend: auto (default) | systemd | pm2. See launch-listmonk.sh for why
+# systemd is preferred: --scope is blocked on May First, an installed unit is not.
+# LISTMONK_SERVICE_MANAGER=auto
+# LISTMONK_SYSTEMD_UNIT=listmonk.service
 #
 # Absolute paths on the newsletter server. These are host specific, so set them in
 # .env.production on that box - no real paths belong in this template.

--- a/.env.template
+++ b/.env.template
@@ -159,6 +159,18 @@ LISTMONK_HEALTHCHECK_PING_URL=https://hc-ping.com/your-listmonk-check-uuid
 # LISTMONK_SUBSCRIPTION_PATH=/subscription
 # LISTMONK_PM2_APP_NAME=listmonk
 #
+# Round-trip probe: POSTs a real subscribe to the SITE endpoint the footer form
+# uses, so the check covers ac-api -> listmonk -> postgres and not just the port.
+# Leave LISTMONK_SUBSCRIBE_URL empty to disable the round trip.
+# The default address is RFC 2606 reserved (never deliverable) and listmonk's 409
+# on a repeat makes it a single permanent row, not a new subscriber every run.
+# LISTMONK_SUBSCRIBE_URL=https://example.org/api-server/subscribe
+# LISTMONK_SUBSCRIBE_TEST_EMAIL=healthcheck@example.com
+# LISTMONK_SUBSCRIBE_TEST_NAME=Healthcheck Monitor
+# LISTMONK_ROUNDTRIP_TIMEOUT=20
+# Set to 0 only if the host has no systemd user session (see launch-listmonk.sh).
+# LISTMONK_PM2_SCOPE=1
+#
 # Absolute paths on the newsletter server. These are host specific, so set them in
 # .env.production on that box - no real paths belong in this template.
 # LISTMONK_BIN=/absolute/path/to/listmonk

--- a/__tests__/listmonk-roundtrip.test.js
+++ b/__tests__/listmonk-roundtrip.test.js
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const LIB = path.resolve(import.meta.dirname, '../scripts/lib/listmonk-roundtrip.sh')
+
+/** Run classify_roundtrip from the shell lib and return its verdict. */
+function classify(code, body = '') {
+  return execFileSync(
+    'bash',
+    ['-c', 'source "$1"; classify_roundtrip "$2" "$3"', 'bash', LIB, String(code), body],
+    { encoding: 'utf8' }
+  ).trim()
+}
+
+describe('classify_roundtrip', () => {
+  it('passes when the site API reports a successful subscribe', () => {
+    expect(classify(200, '{"success":true,"status":200,"data":{"id":42}}')).toBe('PASS')
+  })
+
+  // The whole reason this monitor exists: api/subscribe.js returns its result
+  // object rather than setting a status, so a dead listmonk still answers 200.
+  it('fails on HTTP 200 that carries success:false', () => {
+    expect(
+      classify(200, '{"success":false,"status":500,"error":"Something went wrong. Please try again."}')
+    ).toBe('FAIL')
+  })
+
+  it('fails on HTTP 200 with an empty or non-JSON body', () => {
+    expect(classify(200, '')).toBe('FAIL')
+    expect(classify(200, '<html>maintenance</html>')).toBe('FAIL')
+  })
+
+  it('does not match a success field that is false-y or renamed', () => {
+    expect(classify(200, '{"success":"true"}')).toBe('FAIL')
+    expect(classify(200, '{"successful":true}')).toBe('FAIL')
+  })
+
+  it('tolerates whitespace around the success value', () => {
+    expect(classify(200, '{ "success" : true }')).toBe('PASS')
+  })
+
+  // Rate limiting proves nothing either way, and must never trigger a restart.
+  it('treats rate limiting as inconclusive', () => {
+    expect(classify(429, '<html><title>429 Too Many Requests</title></html>')).toBe('INCONCLUSIVE')
+    expect(classify(429, '{"statusCode":429,"error":"Too Many Requests"}')).toBe('INCONCLUSIVE')
+  })
+
+  it('flags client-side rejections as monitor misconfiguration', () => {
+    for (const code of [400, 401, 403, 404, 405, 422]) {
+      expect(classify(code, '{"error":"nope"}')).toBe('BAD_REQUEST')
+    }
+  })
+
+  // Restarting listmonk cannot fix a dead site API, so these stay distinct.
+  it('reports upstream failures when the site API is unreachable or erroring', () => {
+    expect(classify('000', '')).toBe('UPSTREAM_DOWN')
+    expect(classify(500, 'boom')).toBe('UPSTREAM_DOWN')
+    expect(classify(502, '<html>502</html>')).toBe('UPSTREAM_DOWN')
+    expect(classify(503, '<html>Service Unavailable</html>')).toBe('UPSTREAM_DOWN')
+  })
+
+  it('does not treat unexpected 2xx/3xx as a healthy round trip', () => {
+    expect(classify(204, '')).toBe('UPSTREAM_DOWN')
+    expect(classify(301, '')).toBe('UPSTREAM_DOWN')
+  })
+})

--- a/scripts/healthcheck-listmonk.sh
+++ b/scripts/healthcheck-listmonk.sh
@@ -3,12 +3,32 @@
 # Health check + auto-restart for listmonk.
 #
 # Runs on the newsletter server (the box that hosts listmonk under PM2), not on
-# the main site server. Probes the public health API; if listmonk is down it runs
-# launch-listmonk.sh, then pings Healthchecks.io once the service answers again.
+# the main site server. Two independent probes:
 #
-# Cron example (every 5 minutes, plus a catch-up after reboot):
-#   */5 * * * * /path/to/repo/scripts/healthcheck-listmonk.sh
-#   @reboot sleep 60 && /path/to/repo/scripts/healthcheck-listmonk.sh
+#   1. Liveness  - listmonk's own /api/health (fallback: the public /subscription
+#                  page). Proves the process is listening.
+#   2. Round trip - POST a real subscribe to the SITE's public endpoint, the same
+#                  one the footer form calls. Proves the whole chain works:
+#                  site nginx -> ac-api (Fastify) -> lib/listmonk -> listmonk -> postgres.
+#
+# The round trip is the one that catches real outages. api/subscribe.js returns
+# its result object instead of setting a status code, so Fastify answers HTTP 200
+# even when listmonk is unreachable - a status-code-only monitor reports green
+# against a completely dead newsletter. See scripts/lib/listmonk-roundtrip.sh.
+#
+# Repeat runs do not pollute the subscriber table: lib/listmonk.js treats
+# listmonk's 409 "e-mail already exists" as success, so the monitor address is
+# inserted once and re-confirmed every run afterwards.
+#
+# Scheduling: run it every 5 minutes. May First no longer honours user crontabs
+# on these hosts - `crontab -l` is refused outright - so the job is defined in the
+# control panel, which generates ~/.config/systemd/user/red-item-<id>.{service,timer}.
+# Verify it is actually scheduled, because a missing job looks exactly like a
+# healthy service that never alerts:
+#   systemctl --user list-timers
+#   journalctl --user -u red-item-<id>.service
+# Those generated units are Type=oneshot, which is why launch-listmonk.sh has to
+# put PM2 in its own systemd scope - see the note in that file.
 #
 # Required env (see .env.production on the newsletter server):
 #   LISTMONK_HEALTHCHECK_PING_URL — Healthchecks.io ping URL
@@ -17,11 +37,15 @@
 # Optional env:
 #   LISTMONK_HEALTH_PATH / LISTMONK_SUBSCRIPTION_PATH
 #   LISTMONK_HEALTH_MARKER / LISTMONK_SUBSCRIPTION_MARKER
-#   LISTMONK_LAUNCH_SCRIPT     — default: <repo>/scripts/launch-listmonk.sh
-#   LISTMONK_LAUNCH_TIMEOUT    — seconds to allow the launcher (default 90)
-#   LISTMONK_START_ATTEMPTS    — post-start probes (default 6)
-#   LISTMONK_START_RETRY_SLEEP — seconds between probes (default 5)
-#   LOG_DIR / LOG_LINES_KEEP   — shared server log settings
+#   LISTMONK_SUBSCRIBE_URL         — site subscribe endpoint; empty disables the round trip
+#   LISTMONK_SUBSCRIBE_TEST_EMAIL  — monitor address (default healthcheck@example.com)
+#   LISTMONK_SUBSCRIBE_TEST_NAME   — monitor display name
+#   LISTMONK_ROUNDTRIP_TIMEOUT     — seconds for the subscribe POST (default 20)
+#   LISTMONK_LAUNCH_SCRIPT         — default: <repo>/scripts/launch-listmonk.sh
+#   LISTMONK_LAUNCH_TIMEOUT        — seconds to allow the launcher (default 90)
+#   LISTMONK_START_ATTEMPTS        — post-start probes (default 6)
+#   LISTMONK_START_RETRY_SLEEP     — seconds between probes (default 5)
+#   LOG_DIR / LOG_LINES_KEEP       — shared server log settings
 #
 set -euo pipefail
 
@@ -31,6 +55,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/load-env.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/log.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/listmonk-roundtrip.sh"
 
 init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "healthcheck-listmonk.log" "$(resolve_server_log_lines_keep)"
 
@@ -51,6 +77,13 @@ LAUNCH_SCRIPT="${LISTMONK_LAUNCH_SCRIPT:-$SCRIPT_DIR/launch-listmonk.sh}"
 LAUNCH_TIMEOUT="${LISTMONK_LAUNCH_TIMEOUT:-90}"
 START_ATTEMPTS="${LISTMONK_START_ATTEMPTS:-6}"
 START_RETRY_SLEEP="${LISTMONK_START_RETRY_SLEEP:-5}"
+
+SUBSCRIBE_URL="${LISTMONK_SUBSCRIBE_URL:-}"
+# RFC 2606 reserves example.com, so this address can never be delivered to or
+# bounce. One row in listmonk, reused forever.
+SUBSCRIBE_TEST_EMAIL="${LISTMONK_SUBSCRIBE_TEST_EMAIL:-healthcheck@example.com}"
+SUBSCRIBE_TEST_NAME="${LISTMONK_SUBSCRIBE_TEST_NAME:-Healthcheck Monitor}"
+ROUNDTRIP_TIMEOUT="${LISTMONK_ROUNDTRIP_TIMEOUT:-20}"
 
 echo "=== $(date -Iseconds) healthcheck-listmonk (log: $LOG_FILE) ==="
 
@@ -78,25 +111,83 @@ fetch() {
   curl -s -m 5 "$1" 2>/dev/null || true
 }
 
-service_online=false
-
-HEALTH_BODY="$(fetch "$HEALTH_URL")"
-if grep -qF "$HEALTH_MARKER" <<<"$HEALTH_BODY"; then
-  echo "OK: listmonk API is responding at $HEALTH_URL"
-  service_online=true
-else
-  echo "FAIL: health API check (got: $(snippet "$HEALTH_BODY"))"
-  # Fallback: the subscription page is public even when the API session check moves.
-  SUB_BODY="$(fetch "$SUBSCRIPTION_URL")"
-  if grep -qF "$SUBSCRIPTION_MARKER" <<<"$SUB_BODY"; then
-    echo "OK: listmonk web interface is serving content at $SUBSCRIPTION_URL"
-    service_online=true
-  else
-    echo "FAIL: subscription page check ('$SUBSCRIPTION_MARKER' not found)"
+# Liveness only: is something answering on listmonk's own port?
+probe_liveness() {
+  local body
+  body="$(fetch "$HEALTH_URL")"
+  if grep -qF "$HEALTH_MARKER" <<<"$body"; then
+    echo "OK: listmonk API is responding at $HEALTH_URL"
+    return 0
   fi
+  echo "FAIL: health API check (got: $(snippet "$body"))"
+  # Fallback: the subscription page is public even when the API session check moves.
+  body="$(fetch "$SUBSCRIPTION_URL")"
+  if grep -qF "$SUBSCRIPTION_MARKER" <<<"$body"; then
+    echo "OK: listmonk web interface is serving content at $SUBSCRIPTION_URL"
+    return 0
+  fi
+  echo "FAIL: subscription page check ('$SUBSCRIPTION_MARKER' not found)"
+  return 1
+}
+
+# Sets ROUNDTRIP_VERDICT. Budget note: the Fastify limiter on /subscribe allows 5
+# posts per 15 minutes per IP, and a */5 schedule spends 3 of them, so this runs
+# at most twice per invocation (once up front, once to confirm a restart).
+ROUNDTRIP_VERDICT="SKIPPED"
+run_roundtrip() {
+  local label="$1" result code detail
+  if [[ -z "$SUBSCRIBE_URL" ]]; then
+    ROUNDTRIP_VERDICT="SKIPPED"
+    echo "SKIP: round trip disabled (set LISTMONK_SUBSCRIBE_URL to enable)"
+    return 0
+  fi
+
+  result="$(roundtrip_probe "$SUBSCRIBE_URL" "$SUBSCRIBE_TEST_EMAIL" "$SUBSCRIBE_TEST_NAME" "$ROUNDTRIP_TIMEOUT")"
+  ROUNDTRIP_VERDICT="${result%% *}"
+  result="${result#* }"
+  code="${result%% *}"
+  detail="${result#* }"
+
+  case "$ROUNDTRIP_VERDICT" in
+    PASS)
+      echo "OK: $label round trip subscribed $SUBSCRIBE_TEST_EMAIL via $SUBSCRIBE_URL (http=$code)"
+      ;;
+    FAIL)
+      # The 200 here is the trap: the site API answers fine, listmonk does not.
+      echo "FAIL: $label round trip - site API answered http=$code but the subscribe did not succeed: $detail"
+      ;;
+    INCONCLUSIVE)
+      echo "WARN: $label round trip rate limited (http=$code); treating as inconclusive: $detail"
+      ;;
+    BAD_REQUEST)
+      echo "FAIL: $label round trip rejected by the site API (http=$code) - check LISTMONK_SUBSCRIBE_URL and the payload: $detail"
+      ;;
+    UPSTREAM_DOWN)
+      echo "FAIL: $label round trip could not reach the site API (http=$code) - this is the site/ac-api, not listmonk: $detail"
+      ;;
+  esac
+}
+
+liveness_ok=false
+if probe_liveness; then
+  liveness_ok=true
 fi
 
-if [[ "$service_online" == false ]]; then
+run_roundtrip "initial"
+
+# Restart only for problems a listmonk restart can actually fix. A rate-limited
+# probe proves nothing, and a dead site API or a malformed probe is not listmonk's
+# fault - bouncing the service on those just adds an outage to an outage.
+needs_restart=false
+if [[ "$liveness_ok" == false ]]; then
+  needs_restart=true
+elif [[ "$ROUNDTRIP_VERDICT" == "FAIL" ]]; then
+  echo "Listmonk is listening but the subscribe path is broken; restarting anyway."
+  needs_restart=true
+fi
+
+restarted=false
+if [[ "$needs_restart" == true ]]; then
   echo "Attempting to start listmonk..."
   if [[ -x "$LAUNCH_SCRIPT" ]]; then
     # Foreground, with output captured. Backgrounding this into /dev/null is what
@@ -110,29 +201,49 @@ if [[ "$service_online" == false ]]; then
     fi
     echo "Launch script exited rc=$launch_rc"
 
+    liveness_ok=false
     for ((attempt = 1; attempt <= START_ATTEMPTS; attempt++)); do
       sleep "$START_RETRY_SLEEP"
       RETRY_BODY="$(fetch "$HEALTH_URL")"
       if grep -qF "$HEALTH_MARKER" <<<"$RETRY_BODY"; then
         echo "OK: listmonk started (health API confirmed after $((attempt * START_RETRY_SLEEP))s)"
-        service_online=true
+        liveness_ok=true
+        restarted=true
         break
       fi
       echo "  ... attempt $attempt/$START_ATTEMPTS: not up yet (got: $(snippet "$RETRY_BODY"))"
     done
 
-    [[ "$service_online" == false ]] && echo "FAIL: listmonk did not come back up"
+    [[ "$liveness_ok" == false ]] && echo "FAIL: listmonk did not come back up"
   else
     echo "FAIL: launch script missing or not executable: $LAUNCH_SCRIPT"
   fi
 fi
 
+# Re-run the round trip after a restart so a green ping always means the whole
+# subscribe chain was verified, not just that the port reopened.
+if [[ "$restarted" == true ]]; then
+  run_roundtrip "post-restart"
+fi
+
+# Green requires liveness AND a round trip that did not fail. INCONCLUSIVE and
+# SKIPPED stay green: they carry no evidence of an outage, and flapping the alert
+# on a rate limit trains people to ignore it.
+service_online=false
+if [[ "$liveness_ok" == true ]]; then
+  case "$ROUNDTRIP_VERDICT" in
+    PASS | INCONCLUSIVE | SKIPPED) service_online=true ;;
+  esac
+fi
+
+status_line="liveness=$liveness_ok roundtrip=$ROUNDTRIP_VERDICT restarted=$restarted"
+
 if [[ "$service_online" == true ]]; then
-  hc_post "${PING_URL%/}" "healthcheck-listmonk ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL"
-  [[ -n "$PING_URL" ]] && echo "Health check ping sent" || echo "No LISTMONK_HEALTHCHECK_PING_URL set; ping skipped"
+  hc_post "${PING_URL%/}" "healthcheck-listmonk ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL $status_line"
+  [[ -n "$PING_URL" ]] && echo "Health check ping sent ($status_line)" || echo "No LISTMONK_HEALTHCHECK_PING_URL set; ping skipped ($status_line)"
 else
-  hc_post "${PING_URL%/}/fail" "healthcheck-listmonk failed $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL"
-  [[ -n "$PING_URL" ]] && echo "Sent fail ping - listmonk is down" || echo "listmonk is down (no ping URL configured)"
+  hc_post "${PING_URL%/}/fail" "healthcheck-listmonk failed $(date -u +"%Y-%m-%dT%H:%M:%SZ") url=$HEALTH_URL $status_line"
+  [[ -n "$PING_URL" ]] && echo "Sent fail ping - listmonk is down ($status_line)" || echo "listmonk is down ($status_line; no ping URL configured)"
   echo "=== Check complete ==="
   exit 1
 fi

--- a/scripts/launch-listmonk.sh
+++ b/scripts/launch-listmonk.sh
@@ -20,6 +20,15 @@
 #   LISTMONK_PM2_APP_NAME — PM2 process name (default: listmonk)
 #   LISTMONK_NVM_DIR      — nvm install dir to source for node/pm2 on PATH
 #   LISTMONK_PATH_EXTRA   — extra PATH prefix if pm2 lives outside nvm
+#   LISTMONK_PM2_SCOPE    — 0 to skip the systemd scope described below
+#
+# IMPORTANT (systemd): May First now runs scheduled jobs as Type=oneshot user
+# units. Those default to KillMode=control-group, so when the job's script exits
+# systemd SIGTERMs everything left in the unit's cgroup - including the PM2 God
+# daemon this script just started, and listmonk with it. The job looks like it
+# succeeded, which is worse than failing: the service comes up for a few seconds
+# and is killed on the way out. ensure_pm2_daemon() below starts the daemon in a
+# separate transient scope so it survives our exit.
 #
 set -uo pipefail
 
@@ -61,6 +70,62 @@ fi
 
 echo "launch-listmonk: pm2=$(command -v pm2) node=$(command -v node || echo none) PM2_HOME=${PM2_HOME:-<default>}"
 
+pm2_daemon_pid() {
+  local pidfile="${PM2_HOME:-$HOME/.pm2}/pm2.pid" pid
+  [[ -r "$pidfile" ]] || return 1
+  pid="$(cat "$pidfile" 2>/dev/null)" || return 1
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s' "$pid"
+}
+
+# cgroup path of a pid (systemd unified hierarchy), empty when unavailable.
+proc_cgroup() {
+  local pid="$1"
+  [[ -r "/proc/$pid/cgroup" ]] || return 0
+  awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null || true
+}
+
+# Start the PM2 God daemon inside its own transient systemd scope, so it lives in
+# a different cgroup than this (possibly Type=oneshot) job and is not reaped when
+# we exit. Ordering matters: the PM2 CLI auto-spawns the daemon on ANY command,
+# `pm2 list` included, so this must run before every other pm2 invocation.
+ensure_pm2_daemon() {
+  [[ "${LISTMONK_PM2_SCOPE:-1}" == "0" ]] && return 0
+  # Already running: it either survived, or a prior run placed it correctly.
+  pm2_daemon_pid >/dev/null && return 0
+  command -v systemd-run >/dev/null 2>&1 || return 0
+
+  export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  [[ -d "$XDG_RUNTIME_DIR" ]] || return 0
+
+  # --collect reaps the scope once it is empty; the scope itself stays alive as
+  # long as the daemon holds a process in it.
+  if systemd-run --user --scope --quiet --collect \
+    --unit="listmonk-pm2-daemon-$$" -- pm2 ping >/dev/null 2>&1; then
+    echo "launch-listmonk: PM2 daemon started in its own systemd scope"
+  else
+    echo "launch-listmonk: WARN systemd-run scope failed; PM2 may be reaped when this job exits" >&2
+  fi
+}
+
+# Warn when the daemon shares our cgroup, which means systemd will kill it the
+# moment this script returns. Purely diagnostic, but this is the exact condition
+# that let a green health check sit on top of a dead service.
+warn_if_pm2_shares_our_cgroup() {
+  local pid ours theirs
+  pid="$(pm2_daemon_pid)" || return 0
+  ours="$(proc_cgroup "$$")"
+  theirs="$(proc_cgroup "$pid")"
+  [[ -n "$ours" && -n "$theirs" ]] || return 0
+  if [[ "$ours" == "$theirs" ]]; then
+    echo "launch-listmonk: WARN PM2 daemon (pid $pid) is in this job's cgroup ($ours)." >&2
+    echo "                 A Type=oneshot unit will SIGTERM it when this script exits." >&2
+  fi
+}
+
+ensure_pm2_daemon
+
 # Delete then start so a wedged process never lingers into the new run.
 pm2 delete "$APP_NAME" >/dev/null 2>&1 || true
 
@@ -72,5 +137,7 @@ start_rc=$?
 
 # Persist the process list so `pm2 resurrect` has something to restore.
 pm2 save >/dev/null 2>&1 || true
+
+warn_if_pm2_shares_our_cgroup
 
 exit $start_rc

--- a/scripts/launch-listmonk.sh
+++ b/scripts/launch-listmonk.sh
@@ -1,34 +1,45 @@
 #!/usr/bin/env bash
 #
-# Start (or restart) listmonk under PM2 on the newsletter server.
+# Start (or restart) listmonk on the newsletter server.
 #
 # Called by scripts/healthcheck-listmonk.sh, and safe to run by hand.
 #
-# IMPORTANT: this runs from cron, which does NOT source ~/.bashrc. Everything an
-# interactive shell gets from .bashrc - nvm's bin dir on PATH, and PM2_HOME - has
-# to be set up explicitly here. Without it `pm2` is simply not found, and because
-# the caller used to discard output the restart failed silently every 5 minutes.
+# Two backends, picked automatically (override with LISTMONK_SERVICE_MANAGER):
+#
+#   systemd — preferred. Runs listmonk as a transient user unit and lets systemd
+#             supervise it with Restart=always, so a crash is recovered in
+#             seconds instead of waiting for the next health check.
+#   pm2     — fallback for hosts with no systemd user manager. Historic default.
+#
+# WHY systemd IS PREFERRED HERE (do not "simplify" this back to plain PM2):
+# May First runs scheduled jobs as Type=oneshot user units, and those default to
+# KillMode=control-group. When the job's script exits, systemd SIGTERMs
+# everything left in the unit's cgroup - including a PM2 daemon the script just
+# started, and listmonk with it. The job still exits 0, so the health check
+# pinged green while listmonk was alive for ~7 seconds out of every 5 minutes.
+#
+# The obvious escape - `systemd-run --user --scope` - does NOT work on this host:
+#   listmonk-pm2-daemon.scope: Couldn't move process ... Input/output error
+#   listmonk-pm2-daemon.scope: Failed to add PIDs to scope's control group: Permission denied
+# A scope has to migrate an already-running PID into a new cgroup, and cgroup
+# delegation is restricted here. `systemd-run --user --unit=` works, because
+# systemd forks the process directly into the new cgroup and never has to move
+# it. Installing a unit file is also out: ~/.config/systemd/user is root-owned,
+# reserved for the units the control panel generates.
 #
 # Required env (see .env.production on the newsletter server):
 #   LISTMONK_BIN    — absolute path to the listmonk binary
 #   LISTMONK_CONFIG — absolute path to config.toml
 #
 # Optional env:
-#   LISTMONK_STATIC_DIR   — --static-dir passed to listmonk
-#   LISTMONK_PM2_HOME     — PM2 state dir; MUST match the PM2_HOME your shell uses,
-#                           or cron talks to a second, separate PM2 daemon
-#   LISTMONK_PM2_APP_NAME — PM2 process name (default: listmonk)
-#   LISTMONK_NVM_DIR      — nvm install dir to source for node/pm2 on PATH
-#   LISTMONK_PATH_EXTRA   — extra PATH prefix if pm2 lives outside nvm
-#   LISTMONK_PM2_SCOPE    — 0 to skip the systemd scope described below
-#
-# IMPORTANT (systemd): May First now runs scheduled jobs as Type=oneshot user
-# units. Those default to KillMode=control-group, so when the job's script exits
-# systemd SIGTERMs everything left in the unit's cgroup - including the PM2 God
-# daemon this script just started, and listmonk with it. The job looks like it
-# succeeded, which is worse than failing: the service comes up for a few seconds
-# and is killed on the way out. ensure_pm2_daemon() below starts the daemon in a
-# separate transient scope so it survives our exit.
+#   LISTMONK_STATIC_DIR       — --static-dir passed to listmonk
+#   LISTMONK_SERVICE_MANAGER  — auto (default) | systemd | pm2
+#   LISTMONK_SYSTEMD_UNIT     — unit name (default: listmonk.service)
+#   LISTMONK_PM2_HOME         — PM2 state dir; MUST match the PM2_HOME your shell uses,
+#                               or cron talks to a second, separate PM2 daemon
+#   LISTMONK_PM2_APP_NAME     — PM2 process name (default: listmonk)
+#   LISTMONK_NVM_DIR          — nvm install dir to source for node/pm2 on PATH
+#   LISTMONK_PATH_EXTRA       — extra PATH prefix if pm2 lives outside nvm
 #
 set -uo pipefail
 
@@ -40,6 +51,8 @@ APP_NAME="${LISTMONK_PM2_APP_NAME:-listmonk}"
 LISTMONK_BIN="${LISTMONK_BIN:-}"
 LISTMONK_CONFIG="${LISTMONK_CONFIG:-}"
 LISTMONK_STATIC_DIR="${LISTMONK_STATIC_DIR:-}"
+SERVICE_MANAGER="${LISTMONK_SERVICE_MANAGER:-auto}"
+SYSTEMD_UNIT="${LISTMONK_SYSTEMD_UNIT:-listmonk.service}"
 
 if [[ -z "$LISTMONK_BIN" || -z "$LISTMONK_CONFIG" ]]; then
   echo "FATAL: set LISTMONK_BIN and LISTMONK_CONFIG (see .env.production)" >&2
@@ -51,93 +64,128 @@ if [[ ! -x "$LISTMONK_BIN" ]]; then
   exit 1
 fi
 
-# --- cron-safe environment bootstrap ---
-[[ -n "${LISTMONK_PATH_EXTRA:-}" ]] && export PATH="$LISTMONK_PATH_EXTRA:$PATH"
-if [[ -n "${LISTMONK_NVM_DIR:-}" && -s "$LISTMONK_NVM_DIR/nvm.sh" ]]; then
-  export NVM_DIR="$LISTMONK_NVM_DIR"
-  # nvm refuses to load when npm_config_prefix is inherited from a prior setup.
-  unset npm_config_prefix NPM_CONFIG_PREFIX
-  # shellcheck disable=SC1091
-  \. "$NVM_DIR/nvm.sh"
-fi
-[[ -n "${LISTMONK_PM2_HOME:-}" ]] && export PM2_HOME="$LISTMONK_PM2_HOME"
+# --- systemd backend ---------------------------------------------------------
 
-if ! command -v pm2 >/dev/null 2>&1; then
-  echo "FATAL: pm2 not found on PATH ($PATH)." >&2
-  echo "       Set LISTMONK_NVM_DIR or LISTMONK_PATH_EXTRA - cron does not read ~/.bashrc." >&2
-  exit 1
-fi
-
-echo "launch-listmonk: pm2=$(command -v pm2) node=$(command -v node || echo none) PM2_HOME=${PM2_HOME:-<default>}"
-
-pm2_daemon_pid() {
-  local pidfile="${PM2_HOME:-$HOME/.pm2}/pm2.pid" pid
-  [[ -r "$pidfile" ]] || return 1
-  pid="$(cat "$pidfile" 2>/dev/null)" || return 1
-  [[ -n "$pid" ]] || return 1
-  kill -0 "$pid" 2>/dev/null || return 1
-  printf '%s' "$pid"
-}
-
-# cgroup path of a pid (systemd unified hierarchy), empty when unavailable.
-proc_cgroup() {
-  local pid="$1"
-  [[ -r "/proc/$pid/cgroup" ]] || return 0
-  awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null || true
-}
-
-# Start the PM2 God daemon inside its own transient systemd scope, so it lives in
-# a different cgroup than this (possibly Type=oneshot) job and is not reaped when
-# we exit. Ordering matters: the PM2 CLI auto-spawns the daemon on ANY command,
-# `pm2 list` included, so this must run before every other pm2 invocation.
-ensure_pm2_daemon() {
-  [[ "${LISTMONK_PM2_SCOPE:-1}" == "0" ]] && return 0
-  # Already running: it either survived, or a prior run placed it correctly.
-  pm2_daemon_pid >/dev/null && return 0
-  command -v systemd-run >/dev/null 2>&1 || return 0
-
+systemd_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
   export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-  [[ -d "$XDG_RUNTIME_DIR" ]] || return 0
+  [[ -d "$XDG_RUNTIME_DIR" ]] || return 1
+  systemctl --user show-environment >/dev/null 2>&1
+}
 
-  # --collect reaps the scope once it is empty; the scope itself stays alive as
-  # long as the daemon holds a process in it.
-  if systemd-run --user --scope --quiet --collect \
-    --unit="listmonk-pm2-daemon-$$" -- pm2 ping >/dev/null 2>&1; then
-    echo "launch-listmonk: PM2 daemon started in its own systemd scope"
-  else
-    echo "launch-listmonk: WARN systemd-run scope failed; PM2 may be reaped when this job exits" >&2
+# A TRANSIENT unit, not an installed unit file: ~/.config/systemd/user is
+# root-owned on May First, so we cannot drop a .service file there and
+# `systemctl --user enable` is not available to us. systemd-run is.
+#
+# The tradeoff is that a transient unit does not survive a reboot. That is no
+# worse than the PM2 setup it replaces (there is no `pm2 startup` here either),
+# and the health check timer recreates it within 5 minutes of boot.
+launch_with_systemd() {
+  local unit_base="${SYSTEMD_UNIT%.service}"
+  local args=(--config "$LISTMONK_CONFIG")
+  [[ -n "$LISTMONK_STATIC_DIR" ]] && args+=(--static-dir "$LISTMONK_STATIC_DIR")
+
+  command -v systemd-run >/dev/null 2>&1 || return 1
+
+  # A transient unit vanishes when stopped, so there is nothing to restart into;
+  # always tear down and recreate rather than branching on current state.
+  systemctl --user stop "$SYSTEMD_UNIT" >/dev/null 2>&1 || true
+  systemctl --user reset-failed "$SYSTEMD_UNIT" >/dev/null 2>&1 || true
+
+  # Restart=always is the real win over PM2 here: a crash is recovered in
+  # seconds by systemd instead of waiting out the next health check.
+  systemd-run --user --unit="$unit_base" \
+    --description="listmonk newsletter" \
+    --property=Restart=always \
+    --property=RestartSec=5 \
+    --property=WorkingDirectory="$(dirname "$LISTMONK_CONFIG")" \
+    -- "$LISTMONK_BIN" "${args[@]}" >/dev/null 2>&1 || return 1
+
+  echo "launch-listmonk: started $SYSTEMD_UNIT via systemd-run (Restart=always)"
+  systemctl --user is-active "$SYSTEMD_UNIT"
+
+  if [[ "$(loginctl show-user "$(id -u)" -p Linger --value 2>/dev/null)" != "yes" ]]; then
+    echo "launch-listmonk: WARN lingering is off; the user manager (and listmonk) stops at logout." >&2
+    echo "                 Fix with: loginctl enable-linger \$(whoami)" >&2
   fi
 }
 
-# Warn when the daemon shares our cgroup, which means systemd will kill it the
-# moment this script returns. Purely diagnostic, but this is the exact condition
-# that let a green health check sit on top of a dead service.
+# --- pm2 backend -------------------------------------------------------------
+
+launch_with_pm2() {
+  # cron/systemd jobs do not source ~/.bashrc, which is the only place nvm's bin
+  # dir and PM2_HOME get set. Without this pm2 is simply not found, and because
+  # the caller used to discard output the restart failed silently every 5 minutes.
+  [[ -n "${LISTMONK_PATH_EXTRA:-}" ]] && export PATH="$LISTMONK_PATH_EXTRA:$PATH"
+  if [[ -n "${LISTMONK_NVM_DIR:-}" && -s "$LISTMONK_NVM_DIR/nvm.sh" ]]; then
+    export NVM_DIR="$LISTMONK_NVM_DIR"
+    # nvm refuses to load when npm_config_prefix is inherited from a prior setup.
+    unset npm_config_prefix NPM_CONFIG_PREFIX
+    # shellcheck disable=SC1091
+    \. "$NVM_DIR/nvm.sh"
+  fi
+  [[ -n "${LISTMONK_PM2_HOME:-}" ]] && export PM2_HOME="$LISTMONK_PM2_HOME"
+
+  if ! command -v pm2 >/dev/null 2>&1; then
+    echo "FATAL: pm2 not found on PATH ($PATH)." >&2
+    echo "       Set LISTMONK_NVM_DIR or LISTMONK_PATH_EXTRA - cron does not read ~/.bashrc." >&2
+    return 1
+  fi
+
+  echo "launch-listmonk: pm2=$(command -v pm2) node=$(command -v node || echo none) PM2_HOME=${PM2_HOME:-<default>}"
+
+  # Delete then start so a wedged process never lingers into the new run.
+  pm2 delete "$APP_NAME" >/dev/null 2>&1 || true
+
+  local start_args=(--config "$LISTMONK_CONFIG")
+  [[ -n "$LISTMONK_STATIC_DIR" ]] && start_args+=(--static-dir "$LISTMONK_STATIC_DIR")
+
+  pm2 start "$LISTMONK_BIN" --name "$APP_NAME" --interpreter none -- "${start_args[@]}"
+  local rc=$?
+
+  # Persist the process list so `pm2 resurrect` has something to restore.
+  pm2 save >/dev/null 2>&1 || true
+
+  warn_if_pm2_shares_our_cgroup
+  return $rc
+}
+
+# Diagnostic for the PM2 path: if the daemon ended up in our own cgroup and we
+# were run from a Type=oneshot unit, systemd kills it the moment we return. This
+# is the exact condition that kept a green health check on top of a dead service.
 warn_if_pm2_shares_our_cgroup() {
-  local pid ours theirs
-  pid="$(pm2_daemon_pid)" || return 0
-  ours="$(proc_cgroup "$$")"
-  theirs="$(proc_cgroup "$pid")"
-  [[ -n "$ours" && -n "$theirs" ]] || return 0
-  if [[ "$ours" == "$theirs" ]]; then
-    echo "launch-listmonk: WARN PM2 daemon (pid $pid) is in this job's cgroup ($ours)." >&2
-    echo "                 A Type=oneshot unit will SIGTERM it when this script exits." >&2
-  fi
+  local pidfile="${PM2_HOME:-$HOME/.pm2}/pm2.pid" pid ours theirs
+  [[ -r "$pidfile" ]] || return 0
+  pid="$(cat "$pidfile" 2>/dev/null)" || return 0
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null || return 0
+  ours="$(awk -F: '$1 == "0" { print $3; exit }' "/proc/$$/cgroup" 2>/dev/null)"
+  theirs="$(awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null)"
+  [[ -n "$ours" && -n "$theirs" && "$ours" == "$theirs" ]] || return 0
+  echo "launch-listmonk: WARN PM2 daemon (pid $pid) is in this job's cgroup ($ours)." >&2
+  echo "                 A Type=oneshot unit will SIGTERM it when this script exits." >&2
 }
 
-ensure_pm2_daemon
+# --- dispatch ----------------------------------------------------------------
 
-# Delete then start so a wedged process never lingers into the new run.
-pm2 delete "$APP_NAME" >/dev/null 2>&1 || true
-
-start_args=(--config "$LISTMONK_CONFIG")
-[[ -n "$LISTMONK_STATIC_DIR" ]] && start_args+=(--static-dir "$LISTMONK_STATIC_DIR")
-
-pm2 start "$LISTMONK_BIN" --name "$APP_NAME" --interpreter none -- "${start_args[@]}"
-start_rc=$?
-
-# Persist the process list so `pm2 resurrect` has something to restore.
-pm2 save >/dev/null 2>&1 || true
-
-warn_if_pm2_shares_our_cgroup
-
-exit $start_rc
+case "$SERVICE_MANAGER" in
+  systemd)
+    launch_with_systemd
+    exit $?
+    ;;
+  pm2)
+    launch_with_pm2
+    exit $?
+    ;;
+  auto)
+    if systemd_available; then
+      launch_with_systemd && exit 0
+      echo "launch-listmonk: systemd backend failed; falling back to pm2" >&2
+    fi
+    launch_with_pm2
+    exit $?
+    ;;
+  *)
+    echo "FATAL: LISTMONK_SERVICE_MANAGER must be auto, systemd or pm2 (got: $SERVICE_MANAGER)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/lib/listmonk-roundtrip.sh
+++ b/scripts/lib/listmonk-roundtrip.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Round-trip subscribe probe for the listmonk health check.
+# Source this file (do not run standalone):
+#   source "$SCRIPT_DIR/lib/listmonk-roundtrip.sh"
+#
+# Why this exists: probing listmonk's own /api/health only proves the process is
+# listening. The path that actually matters to a reader is
+#   site nginx -> ac-api (Fastify) -> lib/listmonk -> listmonk -> postgres
+# and every hop past nginx can be broken while /api/health still answers. This
+# posts a real subscribe request to the SITE's public endpoint, the same one the
+# footer form calls, and reads the JSON verdict out of the response.
+#
+# The subtle part is that api/subscribe.js *returns* its result object rather
+# than setting a status code, so Fastify answers HTTP 200 even when the
+# subscribe failed. Checking the status code alone reports green for a dead
+# listmonk. The body must say "success":true.
+#
+# Repeat runs do not grow the subscriber table: lib/listmonk.js maps listmonk's
+# 409 "e-mail already exists" onto success, so the monitor address is created
+# once and every later run re-confirms the same row.
+
+# classify_roundtrip <http_code> <body>
+#
+# Echoes exactly one verdict:
+#   PASS          - full round trip confirmed; listmonk accepted the subscriber
+#   FAIL          - the site API answered, but listmonk did not accept it.
+#                   This is the case that means "restart listmonk".
+#   INCONCLUSIVE  - rate limited (nginx in front, or the Fastify limiter on
+#                   /subscribe). Proves nothing either way; never restart on it.
+#   BAD_REQUEST   - the site API rejected our probe payload (schema/validation).
+#                   A monitor misconfiguration, not a listmonk outage.
+#   UPSTREAM_DOWN - the site API itself is unreachable or erroring. Restarting
+#                   listmonk cannot fix this, so it must not trigger one.
+classify_roundtrip() {
+  local code="$1" body="${2:-}"
+
+  case "$code" in
+    429) printf 'INCONCLUSIVE'; return 0 ;;
+    400 | 401 | 403 | 404 | 405 | 422) printf 'BAD_REQUEST'; return 0 ;;
+  esac
+
+  # curl writes 000 when it never got an HTTP response at all (DNS, TLS, timeout).
+  if [[ "$code" == "000" || "$code" -ge 500 ]] 2>/dev/null; then
+    printf 'UPSTREAM_DOWN'
+    return 0
+  fi
+
+  if [[ "$code" == "200" ]]; then
+    # Tolerate whitespace variations from any future serializer change.
+    if [[ "$body" =~ \"success\"[[:space:]]*:[[:space:]]*true ]]; then
+      printf 'PASS'
+    else
+      printf 'FAIL'
+    fi
+    return 0
+  fi
+
+  # Any other 2xx/3xx is not the contract this endpoint documents.
+  printf 'UPSTREAM_DOWN'
+}
+
+# roundtrip_probe <subscribe_url> <email> <name> [timeout_seconds]
+#
+# Echoes "<verdict> <http_code> <single-line body snippet>".
+# Never returns non-zero: the caller decides what a verdict means.
+roundtrip_probe() {
+  local url="$1" email="$2" name="$3" timeout="${4:-20}"
+  local payload response code body
+
+  # jq is not guaranteed on these shared hosts; the two fields are monitor
+  # constants under our control, so a printf is safe here.
+  payload="$(printf '{"email":"%s","name":"%s"}' "$email" "$name")"
+
+  # -s so a failure body is captured rather than dumped; no -f, because a
+  # non-2xx body is exactly what we need to classify.
+  response="$(curl -s -m "$timeout" -w $'\n%{http_code}' \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json' \
+    --data-raw "$payload" \
+    "$url" 2>/dev/null || true)"
+
+  code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+  [[ -z "$code" ]] && code="000"
+  # When curl fails outright the response is just the code with no body.
+  [[ "$body" == "$code" ]] && body=""
+
+  printf '%s %s %s' \
+    "$(classify_roundtrip "$code" "$body")" \
+    "$code" \
+    "$(printf '%s' "$body" | tr -d '\n' | cut -c1-200)"
+}


### PR DESCRIPTION
## What was wrong

Listmonk was down while the health check pinged green. Two separate bugs.

**1. The check could not see the outage.** It only probed listmonk's own `/api/health`, which proves a port is open and nothing more. Meanwhile the live site returned:

```
POST /api-server/subscribe
HTTP 200  {"success":false,"status":500,"error":"Something went wrong. Please try again."}
```

`api/subscribe.js` *returns* its result object instead of setting a status code, so Fastify answers **200 even when listmonk is unreachable**. Any status-code-only monitor reads that as healthy.

**2. The restart never stuck.** May First runs scheduled jobs as `Type=oneshot` user units (`red-item-389398.service`), which default to `KillMode=control-group`. When the job exited, systemd SIGTERMed everything left in its cgroup — including the PM2 daemon the job had just started. From the server log, every 5 minutes: start listmonk → confirm healthy → ping OK → exit → killed. The unit ran 01:40:25→01:40:32. **Listmonk was alive ~7 seconds out of every 300, and the job still exited 0.**

## What changed

- **`scripts/lib/listmonk-roundtrip.sh`** (new) — POSTs a real subscribe to the site's public endpoint, the one the footer form calls, covering nginx → ac-api → lib/listmonk → listmonk → postgres. Verdicts are deliberately distinct: only `FAIL` (API answered, subscribe did not succeed) restarts listmonk. Rate limiting is `INCONCLUSIVE` and an unreachable site API is `UPSTREAM_DOWN`, because restarting listmonk fixes neither.
- **`scripts/healthcheck-listmonk.sh`** — runs the round trip, restarts on a real failure, re-runs the round trip to confirm recovery. A green ping now means the whole subscribe chain was exercised.
- **`scripts/launch-listmonk.sh`** — runs listmonk under `systemd-run --user --unit=listmonk --property=Restart=always` instead of PM2, so it lands in its own cgroup and survives the oneshot job. PM2 stays as a fallback for hosts with no systemd user manager.

The probe address is RFC 2606 reserved (never deliverable) and `lib/listmonk.js` already maps listmonk's 409 onto success, so it is **one permanent subscriber row**, re-confirmed each run, not a new one every 5 minutes.

## Why a transient unit and not a scope or a unit file

Both alternatives were tried on the host and fail:

- `systemd-run --user --scope` → `Failed to add PIDs to scope's control group: Permission denied`. A scope has to migrate a running PID into a new cgroup and delegation is restricted here. It degrades *quietly* — the process keeps running in the caller's cgroup and is still reaped.
- Installing `~/.config/systemd/user/listmonk.service` → that directory is **root-owned**, reserved for control-panel units, so `systemctl --user enable` is unavailable.

`systemd-run --user --unit=` works because systemd forks directly into the new cgroup. Transient units are lost on reboot, but the 5-minute timer recreates them — no worse than PM2, which has no `pm2 startup` here either.

## Verification

On the newsletter server, with the health check driven from a `Type=oneshot` unit matching the real job:

- listmonk **still active 20s after the job exited** (previously ~7s of life per 5 minutes)
- `SIGKILL` of the main pid **recovered automatically** in seconds via `Restart=always`
- the live round trip went from `success:false` to **`success:true`**
- against a local mock with the subscribe path dead, the **old** script exits 0 (green); the new one exits 1 and restarts

`LISTMONK_SUBSCRIBE_URL` has already been added to `.env.production` on the newsletter server, so this takes effect on the next hourly repo sync after merge.

**Tests:** 9 new cases in `__tests__/listmonk-roundtrip.test.js` covering the verdict branches, including the HTTP-200-with-`success:false` trap. Full suite passing. Not covered: the systemd path, which needs a real user manager — verified by hand on the box instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable API health checks with retries and monitoring status updates.
  * Added optional end-to-end subscription verification for Listmonk, including clear success, failure, and upstream-status reporting.
  * Added automatic service management with systemd, while retaining PM2 support and fallback options.
  * Added automatic Listmonk restarts when liveness or subscription checks fail, followed by verification after restart.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->