### PR TITLE
Verify the API health check with a real HTTP probe and keep PM2 out of the job cgroup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -145,8 +145,12 @@ API_HEALTHCHECK_PING_URL=https://hc-ping.com/your-api-check-uuid
 # Restart tuning:
 # API_HEALTH_START_ATTEMPTS=6
 # API_HEALTH_START_RETRY_SLEEP=5
-# Set to 0 only if the host has no systemd user session (see healthcheck-api.sh).
-# API_HEALTH_PM2_SCOPE=1
+# Cgroup isolation for the PM2 daemon. The scheduled job runs as a Type=oneshot
+# systemd unit, which SIGTERMs everything left in its cgroup on exit - including
+# the PM2 daemon this check starts. Leave at 1 so the daemon is placed in its own
+# transient unit; 0 only on hosts with no systemd user session, where the check
+# then reports on the API without claiming the daemon will survive.
+# API_HEALTH_PM2_ISOLATE=1
 
 # === PM2
 # PM2 writes runtime state (logs/pids/modules) under PM2_HOME.

--- a/.env.template
+++ b/.env.template
@@ -107,13 +107,13 @@ REMOTE_SKIP_API=0
 # NEWSLETTER_ENV_PRODUCTION_PATH=/absolute/path/to/repo/.env.production
 # LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE=./.env.production.newsletter.local
 
-# Private scratch directory for shell scripts and Node tooling. /tmp on the web
-# host is world-readable and shared with hundreds of other accounts, so anything
-# staged there (health-check response bodies, images still carrying the EXIF we
-# are about to strip) is readable by all of them. scripts/load-env.sh exports
-# this as TMPDIR/TMP/TEMP and creates it 0700. Leave unset on dev machines and
-# it falls back to $HOME/include/.tmp when that exists, else the system default.
-SCRIPTS_TMPDIR=
+# Private scratch directory for shell scripts and Node tooling. Keeps
+# intermediates (response bodies, media being processed) out of the system temp
+# dir. scripts/load-env.sh exports this as TMPDIR/TMP/TEMP and creates it 0700.
+# Opt-in: set it to an absolute path on the servers, leave it unset everywhere
+# else and the system default is used unchanged.
+# Production value: /home/sites/<site>/include/.tmp
+#SCRIPTS_TMPDIR=
 
 # === Server / cron script logs (healthchecks, api monitor, etc.)
 # One directory; each script writes its own file there (e.g. healthcheck-site.log).

--- a/.env.template
+++ b/.env.template
@@ -119,11 +119,26 @@ HEALTHCHECK_PING_URL=https://hc-ping.com/your-uuid-here
 SITE_URL=https://activistchecklist.org
 GUIDE_PATH=/essentials/
 
-# === scripts/api-health-monitor.sh
+# === scripts/healthcheck-api.sh
 # Optional: set to 1 if your server requires sourcing ~/.bashrc for nvm/pnpm
 API_HEALTH_SOURCE_BASHRC=0
 API_APP_NAME=ac-api
 API_HEALTHCHECK_PING_URL=https://hc-ping.com/your-api-check-uuid
+#
+# HTTP probe: `pm2 status` saying "online" does not mean the API is serving, so
+# the check also fetches an endpoint and asserts on the response BODY. Handlers
+# in this API return their result object rather than setting a status code, so
+# Fastify answers HTTP 200 even on failure - the status code alone proves nothing.
+# Defaults to the loopback port, because this monitor owns ac-api and not nginx;
+# healthcheck-site.sh covers the public URL. Set empty to disable the probe.
+# API_HEALTH_PROBE_URL=http://127.0.0.1:4321/api-server/hello
+# API_HEALTH_PROBE_MARKER=Hello World
+# API_HEALTH_PROBE_TIMEOUT=10
+# Restart tuning:
+# API_HEALTH_START_ATTEMPTS=6
+# API_HEALTH_START_RETRY_SLEEP=5
+# Set to 0 only if the host has no systemd user session (see healthcheck-api.sh).
+# API_HEALTH_PM2_SCOPE=1
 
 # === PM2
 # PM2 writes runtime state (logs/pids/modules) under PM2_HOME.

--- a/.env.template
+++ b/.env.template
@@ -107,6 +107,14 @@ REMOTE_SKIP_API=0
 # NEWSLETTER_ENV_PRODUCTION_PATH=/absolute/path/to/repo/.env.production
 # LOCAL_NEWSLETTER_ENV_PRODUCTION_FILE=./.env.production.newsletter.local
 
+# Private scratch directory for shell scripts and Node tooling. /tmp on the web
+# host is world-readable and shared with hundreds of other accounts, so anything
+# staged there (health-check response bodies, images still carrying the EXIF we
+# are about to strip) is readable by all of them. scripts/load-env.sh exports
+# this as TMPDIR/TMP/TEMP and creates it 0700. Leave unset on dev machines and
+# it falls back to $HOME/include/.tmp when that exists, else the system default.
+SCRIPTS_TMPDIR=
+
 # === Server / cron script logs (healthchecks, api monitor, etc.)
 # One directory; each script writes its own file there (e.g. healthcheck-site.log).
 # Tail line count for trim_log rotation (shared by all scripts).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,20 @@ indefinitely, so anything logged persists until someone notices.
   `api/server.js` already logs one line per request — leaving both on produced a
   351MB log file.
 
+## Temp file rules
+
+The web host is shared: `/tmp` is world-readable and ~318 other accounts live on
+the same machine.
+
+* **Never hardcode `/tmp`** in a script or Node module. Use `mktemp` in shell and
+  `os.tmpdir()` in Node — both follow `TMPDIR`, which `scripts/load-env.sh` points
+  at `~/include/.tmp` (mode 0700) on the servers.
+* For anything sensitive, create a private directory rather than a single file:
+  `mkdtemp` in Node, `mktemp -d` in shell. A predictable name like
+  `/tmp/metadata_temp_<Date.now()><ext>` is both world-readable and guessable —
+  that one staged images that still carried their original EXIF.
+* Always clean up on the error path too, not just on success.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,14 +56,14 @@
 
 This is a site for activists. A visitor IP or a subscriber email sitting in a log
 file is a safety problem, not just a compliance one. PM2 keeps app logs on disk
-indefinitely, so anything logged persists until someone notices.
+until something trims them, so anything logged persists until someone notices.
 
 * **Never log an IP address, email address, name, form body, or contact message.**
   This includes indirect logging: dumping a request body, an API response body, or
   a caught `error` object that carries the payload. Both real leaks we have had
   came from logging a whole object rather than a chosen field — `console.log('...',
   { payload })` and `console.log('...', { data: parsedData })` in `lib/listmonk.js`,
-  which wrote ~1,300 subscriber emails to `include/.pm2/logs/`.
+  which wrote a large number of subscriber emails into the PM2 app log.
 * **Log chosen fields, never whole objects.** `{ status, endpoint }`, not
   `{ status, data }`. If you need to log a caught error, log `error.message`, not
   `error`.
@@ -75,21 +75,20 @@ indefinitely, so anything logged persists until someone notices.
   reach a log line. `api/server.js` reads `x-forwarded-for` for rate limiting only.
 * Keep log volume bounded. Fastify's default per-request logging is disabled in
   `api/start.js` (`disableRequestLogging`) because the `onResponse` hook in
-  `api/server.js` already logs one line per request — leaving both on produced a
-  351MB log file.
+  `api/server.js` already logs one line per request — leaving both on grew the log
+  to hundreds of megabytes.
 
 ## Temp file rules
 
-The web host is shared: `/tmp` is world-readable and ~318 other accounts live on
-the same machine.
+Treat the system temp dir as off limits for anything we would not want another
+local account to read.
 
-* **Never hardcode `/tmp`** in a script or Node module. Use `mktemp` in shell and
-  `os.tmpdir()` in Node — both follow `TMPDIR`, which `scripts/load-env.sh` points
-  at `~/include/.tmp` (mode 0700) on the servers.
+* **Never hardcode a system temp path** in a script or Node module. Use `mktemp`
+  in shell and `os.tmpdir()` in Node — both follow `TMPDIR`, which
+  `scripts/load-env.sh` points at a private 0700 directory on the servers.
 * For anything sensitive, create a private directory rather than a single file:
-  `mkdtemp` in Node, `mktemp -d` in shell. A predictable name like
-  `/tmp/metadata_temp_<Date.now()><ext>` is both world-readable and guessable —
-  that one staged images that still carried their original EXIF.
+  `mkdtemp` in Node, `mktemp -d` in shell. A name built from a timestamp is
+  guessable; we had one staging media that still carried its original metadata.
 * Always clean up on the error path too, not just on success.
 
 <!-- BEGIN:nextjs-agent-rules -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,32 @@
 * Use constant-time comparison for tokens and hashes.
 * Never log secrets, tokens, or PII.
 
+## Logging rules
+
+This is a site for activists. A visitor IP or a subscriber email sitting in a log
+file is a safety problem, not just a compliance one. PM2 keeps app logs on disk
+indefinitely, so anything logged persists until someone notices.
+
+* **Never log an IP address, email address, name, form body, or contact message.**
+  This includes indirect logging: dumping a request body, an API response body, or
+  a caught `error` object that carries the payload. Both real leaks we have had
+  came from logging a whole object rather than a chosen field — `console.log('...',
+  { payload })` and `console.log('...', { data: parsedData })` in `lib/listmonk.js`,
+  which wrote ~1,300 subscriber emails to `include/.pm2/logs/`.
+* **Log chosen fields, never whole objects.** `{ status, endpoint }`, not
+  `{ status, data }`. If you need to log a caught error, log `error.message`, not
+  `error`.
+* Reviewing a diff: any new `console.log` / `console.error` / `log.info` in `api/`
+  or `lib/` whose argument is a bare object or an `error` is the thing to question.
+  Ask "what is actually inside this at runtime?" — a Listmonk or Resend response
+  contains the user's email even when the call succeeded.
+* IP addresses may be used in memory (rate-limit keys, hashing) but must never
+  reach a log line. `api/server.js` reads `x-forwarded-for` for rate limiting only.
+* Keep log volume bounded. Fastify's default per-request logging is disabled in
+  `api/start.js` (`disableRequestLogging`) because the `onResponse` hook in
+  `api/server.js` already logs one line per request — leaving both on produced a
+  351MB log file.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/__tests__/api-probe.test.js
+++ b/__tests__/api-probe.test.js
@@ -1,26 +1,27 @@
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const LIB = path.resolve(import.meta.dirname, '../scripts/lib/api-probe.sh')
+// Read the lib in Node and hand it to bash on stdin, rather than passing its
+// path into `bash -c`. The path derives from import.meta.dirname, and a shell
+// command built from a filesystem-derived value trips CodeQL's
+// js/shell-command-injection-from-environment - fairly, even though a positional
+// argument is not itself injectable. This way no path reaches the shell at all:
+// bash -s reads the script from stdin and takes the test values as $1..$3.
+const LIB_SOURCE = readFileSync(
+  path.resolve(import.meta.dirname, '../scripts/lib/api-probe.sh'),
+  'utf8'
+)
 
 const MARKER = 'Hello World'
 
 /** Run classify_api_probe from the shell lib and return its verdict. */
 function classify(code, body = '', marker = MARKER) {
-  return execFileSync(
-    'bash',
-    [
-      '-c',
-      'source "$1"; classify_api_probe "$2" "$3" "$4"',
-      'bash',
-      LIB,
-      String(code),
-      body,
-      marker,
-    ],
-    { encoding: 'utf8' }
-  ).trim()
+  return execFileSync('bash', ['-s', '--', String(code), body, marker], {
+    encoding: 'utf8',
+    input: `${LIB_SOURCE}\nclassify_api_probe "$1" "$2" "$3"\n`,
+  }).trim()
 }
 
 describe('classify_api_probe', () => {

--- a/__tests__/api-probe.test.js
+++ b/__tests__/api-probe.test.js
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const LIB = path.resolve(import.meta.dirname, '../scripts/lib/api-probe.sh')
+
+const MARKER = 'Hello World'
+
+/** Run classify_api_probe from the shell lib and return its verdict. */
+function classify(code, body = '', marker = MARKER) {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      'source "$1"; classify_api_probe "$2" "$3" "$4"',
+      'bash',
+      LIB,
+      String(code),
+      body,
+      marker,
+    ],
+    { encoding: 'utf8' }
+  ).trim()
+}
+
+describe('classify_api_probe', () => {
+  it('passes when the API serves the expected payload', () => {
+    expect(classify(200, '{"message":"Hello World"}')).toBe('PASS')
+  })
+
+  // The whole reason the probe reads the body: handlers in this API return their
+  // result object instead of setting a status, so Fastify answers 200 on failure
+  // (api/subscribe.js). A status-code-only probe would call all of these healthy.
+  it('fails on HTTP 200 whose body is not our payload', () => {
+    expect(classify(200, '{"success":false,"error":"Something went wrong."}')).toBe('FAIL')
+    expect(classify(200, '{"statusCode":500,"error":"Internal Server Error"}')).toBe('FAIL')
+    expect(classify(200, '<html><body>Maintenance</body></html>')).toBe('FAIL')
+    expect(classify(200, '')).toBe('FAIL')
+  })
+
+  it('does not accept a near-miss payload from another process on the port', () => {
+    expect(classify(200, '{"message":"hello world"}')).toBe('FAIL')
+    expect(classify(200, '{"message":"Hello"}')).toBe('FAIL')
+  })
+
+  it('matches the marker anywhere in the body, whatever the serializer spacing', () => {
+    expect(classify(200, '{ "message" : "Hello World" }')).toBe('PASS')
+    expect(classify(200, '{"ok":true,"message":"Hello World","v":2}')).toBe('PASS')
+  })
+
+  it('treats the marker as a fixed string, not a pattern', () => {
+    // A regex-y marker must only match itself; otherwise an operator-set marker
+    // could silently match far more than intended.
+    expect(classify(200, '{"message":"Hello World"}', 'H.*d')).toBe('FAIL')
+    expect(classify(200, '{"message":"H.*d"}', 'H.*d')).toBe('PASS')
+  })
+
+  it('never passes when no marker is configured', () => {
+    expect(classify(200, '{"message":"Hello World"}', '')).toBe('FAIL')
+  })
+
+  // Rate limiting proves nothing either way, and must never trigger a restart.
+  it('treats rate limiting as inconclusive', () => {
+    expect(classify(429, '{"statusCode":429,"error":"Too Many Requests"}')).toBe('INCONCLUSIVE')
+    expect(classify(429, '<html><title>429 Too Many Requests</title></html>')).toBe('INCONCLUSIVE')
+  })
+
+  // Restarting ac-api cannot fix a probe pointed at the wrong URL, so these stay
+  // distinct from DOWN even though both end up red.
+  it('flags client-side rejections as monitor misconfiguration', () => {
+    for (const code of [400, 401, 403, 404, 405, 422]) {
+      expect(classify(code, '{"error":"nope"}')).toBe('BAD_REQUEST')
+    }
+  })
+
+  // Unlike the listmonk round trip, an unreachable upstream here IS our service.
+  it('reports DOWN when nothing answered or the API is erroring', () => {
+    expect(classify('000', '')).toBe('DOWN')
+    expect(classify(500, '{"statusCode":500}')).toBe('DOWN')
+    expect(classify(502, '<html>502 Bad Gateway</html>')).toBe('DOWN')
+    expect(classify(503, '<html>Service Unavailable</html>')).toBe('DOWN')
+  })
+
+  it('does not treat an unexpected 2xx/3xx as healthy', () => {
+    expect(classify(204, '')).toBe('FAIL')
+    expect(classify(301, '')).toBe('FAIL')
+    expect(classify(302, 'Found')).toBe('FAIL')
+  })
+})

--- a/api/start.js
+++ b/api/start.js
@@ -10,7 +10,15 @@ dotenv.config({
 });
 
 // Instantiate Fastify with the options from server.js (logger is not in server.js so CLI pretty-logs still work)
-const server = Fastify({ logger: true, ...(app.options || {}) });
+// disableRequestLogging: Fastify's default logger writes an "incoming request"
+// and a "request completed" line for every call. The onResponse hook in
+// server.js already logs one concise line per request, so the built-in pair was
+// pure duplication — 1.47M of the 1.8M lines in a 351MB log.
+const server = Fastify({
+  logger: true,
+  disableRequestLogging: true,
+  ...(app.options || {}),
+});
 
 // Register your application as a normal plugin
 server.register(app);

--- a/lib/listmonk.js
+++ b/lib/listmonk.js
@@ -3,6 +3,22 @@ const https = require('https');
 const url = require('url');
 dotenv.config();
 
+// Subscriber email addresses are PII and this client's output is captured by PM2
+// into include/.pm2/logs/ac-api-out.log, which is long-lived and on disk. Log
+// what is useful for debugging a delivery problem — status, list, subscriber id —
+// and never the address itself. See __tests__/listmonk-log-redaction.test.js.
+function redactSubscriberForLog(value) {
+  if (!value || typeof value !== 'object') return value;
+  const { email, name, attribs, ...rest } = value;
+  const redacted = { ...rest };
+  if (email !== undefined) redacted.email = '[REDACTED]';
+  if (name !== undefined) redacted.name = '[REDACTED]';
+  if (attribs !== undefined) redacted.attribs = '[REDACTED]';
+  // Listmonk nests the subscriber one or two levels deep under `data`.
+  if (rest.data !== undefined) redacted.data = redactSubscriberForLog(rest.data);
+  return redacted;
+}
+
 class ListmonkClient {
   constructor(config = {}) {
     this.baseUrl = config.baseUrl || process.env.LISTMONK_API_URL;
@@ -67,11 +83,7 @@ class ListmonkClient {
 
     console.log('Attempting to add subscriber:', {
       endpoint: parsedUrl.toString(),
-      payload,
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': '[REDACTED]',
-      }
+      lists: subscriberLists,
     });
 
     return new Promise((resolve, reject) => {
@@ -93,10 +105,11 @@ class ListmonkClient {
         res.on('end', () => {
           try {
             const parsedData = JSON.parse(data);
+            // Never log the response body: it echoes back the subscriber's
+            // email and name. Status is all that is useful here.
             console.log('Listmonk API response:', {
               status: res.statusCode,
               ok: res.statusCode >= 200 && res.statusCode < 300,
-              data: parsedData
             });
 
             if (res.statusCode >= 200 && res.statusCode < 300 || res.statusCode === 409) {
@@ -108,7 +121,7 @@ class ListmonkClient {
             } else {
               console.error('Listmonk API error:', {
                 status: res.statusCode,
-                data: parsedData,
+                data: redactSubscriberForLog(parsedData),
                 endpoint: parsedUrl.toString()
               });
               const errMsg = process.env.NODE_ENV === 'production'
@@ -144,3 +157,4 @@ class ListmonkClient {
 }
 
 module.exports = ListmonkClient;
+module.exports.redactSubscriberForLog = redactSubscriberForLog;

--- a/lib/metadata-library.cjs
+++ b/lib/metadata-library.cjs
@@ -89,10 +89,10 @@ class MetadataStripper {
         // Write to temp file for exiftool processing.
         //
         // This buffer still carries the XMP that Sharp could not remove, so it is
-        // exactly the data we are trying to destroy — on a shared host it must not
-        // land in world-readable /tmp under a guessable name. mkdtemp creates a
-        // 0700 directory with a random suffix inside os.tmpdir(), which honours
-        // TMPDIR (set to ~/include/.tmp on the server by scripts/load-env.sh).
+        // exactly the data we are trying to destroy. Stage it privately and under
+        // an unpredictable name: mkdtemp creates a 0700 directory with a random
+        // suffix inside os.tmpdir(), which honours the TMPDIR that
+        // scripts/load-env.sh sets.
         const fileExt = originalFilePath ? path.extname(originalFilePath) : '.png'
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'metadata-'))
         const tempPath = path.join(tempDir, `strip${fileExt}`)

--- a/lib/metadata-library.cjs
+++ b/lib/metadata-library.cjs
@@ -1,6 +1,7 @@
 const fs = require('fs/promises')
 const fsSync = require('fs')
 const path = require('path')
+const os = require('os')
 const { execFile } = require('child_process')
 
 // Try to load sharp, but handle gracefully if it fails
@@ -85,10 +86,17 @@ class MetadataStripper {
           console.log(`    ⚠️ Sharp failed to remove XMP, using exiftool fallback`)
         }
 
-        // Write to temp file for exiftool processing
+        // Write to temp file for exiftool processing.
+        //
+        // This buffer still carries the XMP that Sharp could not remove, so it is
+        // exactly the data we are trying to destroy — on a shared host it must not
+        // land in world-readable /tmp under a guessable name. mkdtemp creates a
+        // 0700 directory with a random suffix inside os.tmpdir(), which honours
+        // TMPDIR (set to ~/include/.tmp on the server by scripts/load-env.sh).
         const fileExt = originalFilePath ? path.extname(originalFilePath) : '.png'
-        const tempPath = '/tmp/metadata_temp_' + Date.now() + fileExt
-        await fs.writeFile(tempPath, strippedBuffer)
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'metadata-'))
+        const tempPath = path.join(tempDir, `strip${fileExt}`)
+        await fs.writeFile(tempPath, strippedBuffer, { mode: 0o600 })
 
         try {
           // Use exiftool to remove all metadata
@@ -97,8 +105,8 @@ class MetadataStripper {
           // Read the cleaned file back
           const cleanedBuffer = await fs.readFile(tempPath)
 
-          // Clean up temp file
-          await fs.unlink(tempPath)
+          // Clean up temp dir
+          await fs.rm(tempDir, { recursive: true, force: true })
 
           // Verify XMP was removed (only if Sharp is available)
           const finalMetadata = sharp ? await sharp(cleanedBuffer).metadata() : null
@@ -112,9 +120,10 @@ class MetadataStripper {
 
           return cleanedBuffer
         } catch (exiftoolError) {
-          // Clean up temp file on error
+          // Clean up temp dir on error: leaving it behind would strand an image
+          // that still has its original metadata.
           try {
-            await fs.unlink(tempPath)
+            await fs.rm(tempDir, { recursive: true, force: true })
           } catch { }
           throw new Error(`Both Sharp and exiftool failed to remove XMP metadata: ${exiftoolError.message}`)
         }

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -27,19 +27,37 @@ source "$SCRIPT_DIR/log.sh"
 
 init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "cleanup-tmp.log" "$(resolve_server_log_lines_keep)"
 
-TMP_DIR="${CLEANUP_TMP_DIR:-${TMPDIR:-$HOME/.tmp}}"
-TMP_DIR="${TMP_DIR%/}"
 MIN_AGE="${CLEANUP_TMP_MIN_AGE:-1440}"
 DRY_RUN="${CLEANUP_TMP_DRY_RUN:-0}"
 
-# Only ever prune a real, non-root directory we own. A misconfigured
-# CLEANUP_TMP_DIR should abort, not walk someone's home or /.
-if [[ -z "$TMP_DIR" || "$TMP_DIR" == "/" || "$TMP_DIR" == "$HOME" ]]; then
-  log_echo "ERROR: refusing to prune TMP_DIR='$TMP_DIR'"
-  exit 1
+# Prune the active temp dir (load-env.sh points TMPDIR at ~/include/.tmp on the
+# servers) *and* the legacy ~/.tmp the scheduler still sets for jobs that do not
+# source load-env.sh. Without the second entry the 215MB of pre-pnpm yarn dirs
+# sitting there would never be collected again.
+CANDIDATE_DIRS=()
+if [[ -n "${CLEANUP_TMP_DIR:-}" ]]; then
+  CANDIDATE_DIRS+=("$CLEANUP_TMP_DIR")
+else
+  [[ -n "${TMPDIR:-}" ]] && CANDIDATE_DIRS+=("$TMPDIR")
+  CANDIDATE_DIRS+=("$HOME/include/.tmp" "$HOME/.tmp")
 fi
-if [[ ! -d "$TMP_DIR" ]]; then
-  log_echo "Nothing to do: $TMP_DIR does not exist"
+
+# Only ever prune a real, non-root directory we own, and never the same one
+# twice. A misconfigured path should abort, not walk someone's home or /.
+TMP_DIRS=()
+for d in "${CANDIDATE_DIRS[@]}"; do
+  d="${d%/}"
+  [[ -z "$d" || "$d" == "/" || "$d" == "$HOME" ]] && continue
+  [[ -d "$d" ]] || continue
+  seen=0
+  for existing in ${TMP_DIRS[@]+"${TMP_DIRS[@]}"}; do
+    [[ "$existing" == "$d" ]] && seen=1 && break
+  done
+  (( seen )) || TMP_DIRS+=("$d")
+done
+
+if (( ${#TMP_DIRS[@]} == 0 )); then
+  log_echo "Nothing to do: no prunable temp directory found"
   exit 0
 fi
 
@@ -58,22 +76,27 @@ fi
 # node rebuilds, not orphaned working directories.
 PATTERNS=('yarn--*' 'pnpm-*' 'npm-*' 'tmp.*')
 
-log_echo "=== cleanup-tmp started dir=$TMP_DIR min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
-before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+log_echo "=== cleanup-tmp started dirs='${TMP_DIRS[*]}' min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
 
-removed=0
-for pattern in "${PATTERNS[@]}"; do
-  # -mindepth 1 keeps $TMP_DIR itself out of the match set.
-  while IFS= read -r -d '' entry; do
-    if [[ "$DRY_RUN" == "1" ]]; then
-      log_echo "would remove: $entry"
-    else
-      rm -rf -- "$entry"
-    fi
-    removed=$((removed + 1))
-  done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+total_removed=0
+for TMP_DIR in "${TMP_DIRS[@]}"; do
+  before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+  removed=0
+  for pattern in "${PATTERNS[@]}"; do
+    # -mindepth 1 keeps $TMP_DIR itself out of the match set.
+    while IFS= read -r -d '' entry; do
+      if [[ "$DRY_RUN" == "1" ]]; then
+        log_echo "would remove: $entry"
+      else
+        rm -rf -- "$entry"
+      fi
+      removed=$((removed + 1))
+    done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+  done
+  after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+  log_echo "$TMP_DIR: removed=$removed size ${before_size:-?} -> ${after_size:-?}"
+  total_removed=$((total_removed + removed))
 done
 
-after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
-log_echo "=== cleanup-tmp done removed=$removed size ${before_size:-?} -> ${after_size:-?} ==="
+log_echo "=== cleanup-tmp done removed=$total_removed across ${#TMP_DIRS[@]} dir(s) ==="
 trim_log

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -2,11 +2,11 @@
 #
 # Prune stale temp directories left behind by package managers and build tooling.
 #
-# Replaces two control-panel jobs that pointed at /tmp with a malformed
-# `find ... -exec -delete`. Both were also looking in the wrong place: the
-# scheduler sets TMPDIR to ~/.tmp, so nothing lands in /tmp any more. By the time
-# this script was written ~/.tmp held 439 orphaned `yarn--*` directories going
-# back to 2024 (215MB), none of them newer than the pnpm migration.
+# Replaces two scheduled jobs that pointed at the system temp dir with a
+# malformed `find ... -exec -delete`. Both were also looking in the wrong place:
+# the scheduler sets TMPDIR under the account's own home. Orphaned `yarn--*`
+# directories predating the pnpm migration had been accumulating there for
+# months.
 #
 # Scheduler example (daily):
 #   /absolute/path/to/repo/scripts/cleanup-tmp.sh
@@ -32,8 +32,8 @@ DRY_RUN="${CLEANUP_TMP_DRY_RUN:-0}"
 
 # Prune the active temp dir (load-env.sh points TMPDIR at ~/include/.tmp on the
 # servers) *and* the legacy ~/.tmp the scheduler still sets for jobs that do not
-# source load-env.sh. Without the second entry the 215MB of pre-pnpm yarn dirs
-# sitting there would never be collected again.
+# source load-env.sh. Without the second entry the older directory would stop
+# being collected entirely once TMPDIR moved.
 CANDIDATE_DIRS=()
 if [[ -n "${CLEANUP_TMP_DIR:-}" ]]; then
   CANDIDATE_DIRS+=("$CLEANUP_TMP_DIR")
@@ -42,18 +42,38 @@ else
   CANDIDATE_DIRS+=("$HOME/include/.tmp" "$HOME/.tmp")
 fi
 
-# Only ever prune a real, non-root directory we own, and never the same one
-# twice. A misconfigured path should abort, not walk someone's home or /.
+# This script runs `rm -rf`, so be strict about what it will accept. Resolve each
+# candidate to a real path first: a string comparison alone would let a value
+# like "$HOME/include/.tmp/../.." past the checks below, and a symlink could
+# point anywhere. Then require the result to sit strictly inside $HOME, so a
+# misconfigured CLEANUP_TMP_DIR aborts rather than walking an unrelated tree.
+CONTAINMENT_ROOT="${CLEANUP_TMP_ROOT:-$HOME}"
+CONTAINMENT_ROOT="$(cd "$CONTAINMENT_ROOT" 2>/dev/null && pwd -P || printf '%s' "$CONTAINMENT_ROOT")"
+
 TMP_DIRS=()
 for d in "${CANDIDATE_DIRS[@]}"; do
   d="${d%/}"
-  [[ -z "$d" || "$d" == "/" || "$d" == "$HOME" ]] && continue
+  [[ -n "$d" ]] || continue
   [[ -d "$d" ]] || continue
+
+  # pwd -P resolves symlinks and .. segments.
+  resolved="$(cd "$d" 2>/dev/null && pwd -P)" || continue
+  [[ -n "$resolved" ]] || continue
+
+  if [[ "$resolved" == "/" || "$resolved" == "$CONTAINMENT_ROOT" ]]; then
+    log_echo "refusing to prune '$d' (resolves to '$resolved')"
+    continue
+  fi
+  if [[ "$resolved" != "$CONTAINMENT_ROOT"/* ]]; then
+    log_echo "refusing to prune '$d': outside '$CONTAINMENT_ROOT' (resolves to '$resolved')"
+    continue
+  fi
+
   seen=0
   for existing in ${TMP_DIRS[@]+"${TMP_DIRS[@]}"}; do
-    [[ "$existing" == "$d" ]] && seen=1 && break
+    [[ "$existing" == "$resolved" ]] && seen=1 && break
   done
-  (( seen )) || TMP_DIRS+=("$d")
+  (( seen )) || TMP_DIRS+=("$resolved")
 done
 
 if (( ${#TMP_DIRS[@]} == 0 )); then

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Prune stale temp directories left behind by package managers and build tooling.
+#
+# Replaces two control-panel jobs that pointed at /tmp with a malformed
+# `find ... -exec -delete`. Both were also looking in the wrong place: the
+# scheduler sets TMPDIR to ~/.tmp, so nothing lands in /tmp any more. By the time
+# this script was written ~/.tmp held 439 orphaned `yarn--*` directories going
+# back to 2024 (215MB), none of them newer than the pnpm migration.
+#
+# Scheduler example (daily):
+#   /absolute/path/to/repo/scripts/cleanup-tmp.sh
+#
+# Env vars:
+#   CLEANUP_TMP_DIR      — directory to prune (default: $TMPDIR, else $HOME/.tmp)
+#   CLEANUP_TMP_MIN_AGE  — minutes; only entries older than this go (default: 1440)
+#   CLEANUP_TMP_DRY_RUN  — 1 to list what would be removed without deleting
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "cleanup-tmp.log" "$(resolve_server_log_lines_keep)"
+
+TMP_DIR="${CLEANUP_TMP_DIR:-${TMPDIR:-$HOME/.tmp}}"
+TMP_DIR="${TMP_DIR%/}"
+MIN_AGE="${CLEANUP_TMP_MIN_AGE:-1440}"
+DRY_RUN="${CLEANUP_TMP_DRY_RUN:-0}"
+
+# Only ever prune a real, non-root directory we own. A misconfigured
+# CLEANUP_TMP_DIR should abort, not walk someone's home or /.
+if [[ -z "$TMP_DIR" || "$TMP_DIR" == "/" || "$TMP_DIR" == "$HOME" ]]; then
+  log_echo "ERROR: refusing to prune TMP_DIR='$TMP_DIR'"
+  exit 1
+fi
+if [[ ! -d "$TMP_DIR" ]]; then
+  log_echo "Nothing to do: $TMP_DIR does not exist"
+  exit 0
+fi
+
+# Leftovers from yarn (pre-pnpm), pnpm, npm, and mktemp. Anything not matching
+# these stays put — this runs unattended and should not guess. Deliberately
+# excludes v8-compile-cache-* and node-compile-cache: those are live caches that
+# node rebuilds, not orphaned working directories.
+PATTERNS=('yarn--*' 'pnpm-*' 'npm-*' 'tmp.*')
+
+log_echo "=== cleanup-tmp started dir=$TMP_DIR min_age_min=$MIN_AGE dry_run=$DRY_RUN ==="
+before_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+
+removed=0
+for pattern in "${PATTERNS[@]}"; do
+  # -mindepth 1 keeps $TMP_DIR itself out of the match set.
+  while IFS= read -r -d '' entry; do
+    if [[ "$DRY_RUN" == "1" ]]; then
+      log_echo "would remove: $entry"
+    else
+      rm -rf -- "$entry"
+    fi
+    removed=$((removed + 1))
+  done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -name "$pattern" -mmin "+$MIN_AGE" -print0 2>/dev/null)
+done
+
+after_size="$(du -sh "$TMP_DIR" 2>/dev/null | awk '{print $1}')"
+log_echo "=== cleanup-tmp done removed=$removed size ${before_size:-?} -> ${after_size:-?} ==="
+trim_log

--- a/scripts/cleanup-tmp.sh
+++ b/scripts/cleanup-tmp.sh
@@ -43,6 +43,15 @@ if [[ ! -d "$TMP_DIR" ]]; then
   exit 0
 fi
 
+# A non-numeric age makes find reject the -mmin argument, which (with stderr
+# discarded) would silently prune nothing forever. A too-small one is worse: it
+# would delete the working directories of builds that are still running. Require
+# an integer, floor at an hour.
+if [[ ! "$MIN_AGE" =~ ^[0-9]+$ ]] || (( MIN_AGE < 60 )); then
+  log_echo "ERROR: CLEANUP_TMP_MIN_AGE must be an integer >= 60 minutes (got '$MIN_AGE')"
+  exit 1
+fi
+
 # Leftovers from yarn (pre-pnpm), pnpm, npm, and mktemp. Anything not matching
 # these stays put — this runs unattended and should not guess. Deliberately
 # excludes v8-compile-cache-* and node-compile-cache: those are live caches that

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -40,6 +40,10 @@ rsync -avz --delete "${RSYNC_EXCLUDE[@]}" "$ROOT/out/" "$FTP_USER@$FTP_HOST:$FTP
 
 echo "===> Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."
 rsync -avz "$LOCAL_ENV_PRODUCTION_FILE" "$FTP_USER@$FTP_HOST:$ENV_PRODUCTION_PATH"
+# rsync -a implies -p, so the remote file takes the local file's mode. Pin it
+# owner-only here as well as in deploy-secrets.sh: this path uploads the same
+# file, so without it a full deploy would widen what deploy:secrets narrowed.
+ssh "$FTP_USER@$FTP_HOST" "chmod 600 '$ENV_PRODUCTION_PATH'"
 
 if [[ "$REMOTE_SKIP_GIT" == "1" ]]; then
   echo "===> Skipping git pull (REMOTE_SKIP_GIT=1)."

--- a/scripts/deploy-secrets.sh
+++ b/scripts/deploy-secrets.sh
@@ -48,6 +48,11 @@ fi
 
 echo "===> [site] Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."
 rsync -avz "$LOCAL_ENV_PRODUCTION_FILE" "$FTP_USER@$FTP_HOST:$ENV_PRODUCTION_PATH"
+# rsync -a implies -p, so the remote file inherits the *local* file's mode: a 644
+# copy here would silently re-widen the server's env file on every deploy. This
+# holds API keys and IP_HASH_SALT, so pin it owner-only regardless of local mode.
+# The newsletter branch below does the same.
+ssh "$FTP_USER@$FTP_HOST" "chmod 600 '$ENV_PRODUCTION_PATH'"
 
 echo "===> [site] Syncing public/webhooks/ to $FTP_HOST:$FTP_DIR/webhooks/ ..."
 # Exclude webhook-secrets.local.php from this pass: with --delete, an absent local copy would

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -100,6 +100,14 @@ nvm_pnpm_err() {
 init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "api-health-monitor.log" "$(resolve_server_log_lines_keep)"
 mkdir -p "$PM2_HOME" "$PM2_HOME/logs" "$PM2_HOME/pids" "$PM2_HOME/modules"
 
+# Scratch file for pm2 output. NOT a command substitution: pm2 auto-spawns its
+# God daemon, the daemon inherits our stdout, and $( ) blocks until every writer
+# closes the pipe - i.e. until the daemon exits. Wrapping a pm2 call that might
+# spawn it in $( ) can therefore hang the monitor outright. Every pm2 invocation
+# below also gets </dev/null so the daemon cannot hold our stdin either.
+PM2_OUT_TMP="$(mktemp "${TMPDIR:-/tmp}/ac-api-health.XXXXXX")"
+trap 'rm -f "$PM2_OUT_TMP"' EXIT
+
 hc_post() {
   local url="$1"
   local body="$2"
@@ -226,7 +234,7 @@ ensure_pm2_daemon() {
   # next attempt just pings that misplaced daemon and declares success. Safe to
   # kill here: we only reach this point when no daemon was running on entry, so
   # nothing is parented to it yet.
-  nvm_pnpm exec pm2 kill >/dev/null 2>&1 || true
+  nvm_pnpm exec pm2 kill >/dev/null 2>&1 </dev/null || true
 
   # Attempt 2: a scope. Tried second, not first, because on these hosts cgroup
   # delegation to the user manager is restricted and a scope cannot migrate an
@@ -303,11 +311,10 @@ run_probe() {
 }
 
 pm2_is_online() {
-  local output
-  output="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
-  printf '%s\n' "$output" >> "$LOG_FILE"
-  PM2_OUTPUT="$output"
-  grep -q "online" <<<"$output"
+  nvm_pnpm exec pm2 status "$APP_NAME" --no-color >"$PM2_OUT_TMP" 2>&1 </dev/null || true
+  cat "$PM2_OUT_TMP" >> "$LOG_FILE"
+  PM2_OUTPUT="$(cat "$PM2_OUT_TMP")"
+  grep -q "online" "$PM2_OUT_TMP"
 }
 
 # --- main ---
@@ -373,8 +380,8 @@ fi
 
 if [[ "$needs_restart" == true ]]; then
   log_echo "Attempting to start/restart $APP_NAME..."
-  START_OUTPUT="$(nvm_pnpm api:start 2>&1 || true)"
-  printf '%s\n' "$START_OUTPUT" >> "$LOG_FILE"
+  nvm_pnpm api:start >"$PM2_OUT_TMP" 2>&1 </dev/null || true
+  cat "$PM2_OUT_TMP" >> "$LOG_FILE"
 
   pm2_online=false
   for ((attempt = 1; attempt <= START_ATTEMPTS; attempt++)); do

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -43,7 +43,7 @@
 #   API_APP_NAME               — PM2 process name (default: ac-api)
 #   API_HEALTHCHECK_PING_URL   — Healthchecks.io ping URL
 #   API_HEALTH_PM2_HOME        — PM2 state dir (default: <repo>/.pm2)
-#   API_HEALTH_PM2_SCOPE       — 0 to skip the cgroup isolation described above
+#   API_HEALTH_PM2_ISOLATE     — 0 to skip the cgroup isolation described above
 #   API_HEALTH_PROBE_URL       — HTTP probe target; empty disables the probe
 #   API_HEALTH_PROBE_MARKER    — string the probe body must contain
 #   API_HEALTH_PROBE_TIMEOUT   — seconds for the probe request (default 10)
@@ -202,7 +202,7 @@ pm2_unit_setenv_args() {
 #   bad - we could not place it; it will be reaped when this script exits
 PM2_DAEMON_PLACED="na"
 ensure_pm2_daemon() {
-  if [[ "${API_HEALTH_PM2_SCOPE:-1}" == "0" ]]; then
+  if [[ "${API_HEALTH_PM2_ISOLATE:-1}" == "0" ]]; then
     PM2_DAEMON_PLACED="na"
     return 0
   fi

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -1,14 +1,51 @@
 #!/usr/bin/env bash
 #
-# API health monitor for PM2 app.
-# - Checks whether APP_NAME is online in PM2
-# - Attempts restart/start if not online
-# - Sends Healthchecks ping on success
+# Health check + auto-restart for the ac-api Fastify server (PM2 app "ac-api").
 #
-# Cron example:
-# */5 * * * * /absolute/path/to/repo/scripts/api-health-monitor.sh >/dev/null 2>&1
+# Runs on the main site host. Two independent probes:
+#
+#   1. PM2 state - is APP_NAME listed as "online"?
+#   2. HTTP probe - does the API actually serve its expected payload?
+#
+# The second one is the one that catches real outages. "online" in `pm2 status`
+# only means PM2 has a child it has not seen exit: it says nothing about whether
+# Fastify bound the port, whether the routes registered, or whether a wedged
+# event loop is refusing every request. This monitor used to ping Healthchecks
+# green on that text alone. See scripts/lib/api-probe.sh for why the probe has to
+# assert on the response body and not just the status code (api/subscribe.js
+# returns its result object, so Fastify answers HTTP 200 even on failure).
+#
+# Scheduling: run it every 5 minutes. May First no longer honours user crontabs on
+# these hosts, so the job is defined in the control panel, which generates
+# ~/.config/systemd/user/red-item-<id>.{service,timer}. Verify it is actually
+# scheduled, because a missing job looks exactly like a healthy service that
+# never alerts:
+#   systemctl --user list-timers
+#   journalctl --user -u red-item-<id>.service
+#
+# IMPORTANT (systemd): those generated units are Type=oneshot, which defaults to
+# KillMode=control-group - when this script exits, systemd SIGTERMs everything
+# left in the unit's cgroup. The PM2 CLI auto-spawns the God daemon on ANY
+# command, `pm2 status` included, so a plain first call adopts the daemon (and
+# ac-api with it) into the doomed cgroup: the check restarts the API, reports
+# green, and then kills it on the way out. ensure_pm2_daemon() below places the
+# daemon in its own cgroup first - a transient scope where that is permitted, a
+# transient unit where cgroup delegation is restricted and a scope is refused.
+# See the comments on that function, and scripts/launch-listmonk.sh for the same
+# problem on the newsletter host.
 #
 # Logs: LOG_DIR (or <repo>/logs); trim lines from LOG_LINES_KEEP (or 500).
+#
+# Optional env (see .env.template):
+#   API_APP_NAME               — PM2 process name (default: ac-api)
+#   API_HEALTHCHECK_PING_URL   — Healthchecks.io ping URL
+#   API_HEALTH_PM2_HOME        — PM2 state dir (default: <repo>/.pm2)
+#   API_HEALTH_PM2_SCOPE       — 0 to skip the systemd scope described above
+#   API_HEALTH_PROBE_URL       — HTTP probe target; empty disables the probe
+#   API_HEALTH_PROBE_MARKER    — string the probe body must contain
+#   API_HEALTH_PROBE_TIMEOUT   — seconds for the probe request (default 10)
+#   API_HEALTH_START_ATTEMPTS  — post-restart probes (default 6)
+#   API_HEALTH_START_RETRY_SLEEP — seconds between probes (default 5)
 #
 set -euo pipefail
 
@@ -26,12 +63,25 @@ fi
 source "$SCRIPT_DIR/load-env.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/log.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/api-probe.sh"
 
 PROJECT_DIR="${PROJECT_DIR:-$ROOT_DIR}"
 APP_NAME="${API_APP_NAME:-ac-api}"
 API_HEALTHCHECK_PING_URL="${API_HEALTHCHECK_PING_URL:-}"
 PM2_HOME="${API_HEALTH_PM2_HOME:-$PROJECT_DIR/.pm2}"
 export PM2_HOME
+
+# Probe the loopback port directly rather than the public URL: this monitor owns
+# ac-api, not nginx, and restarting the app cannot fix a proxy or TLS problem.
+# scripts/healthcheck-site.sh already covers the public path.
+PROBE_URL="${API_HEALTH_PROBE_URL-http://127.0.0.1:${API_PORT:-4321}/api-server/hello}"
+# The distinctive half of /api-server/hello's {"message":"Hello World"} response.
+# Matching the value, not the whole JSON, survives serializer whitespace changes.
+PROBE_MARKER="${API_HEALTH_PROBE_MARKER:-Hello World}"
+PROBE_TIMEOUT="${API_HEALTH_PROBE_TIMEOUT:-10}"
+START_ATTEMPTS="${API_HEALTH_START_ATTEMPTS:-6}"
+START_RETRY_SLEEP="${API_HEALTH_START_RETRY_SLEEP:-5}"
 
 # Shared nvm-pnpm lib (scripts/lib/nvm-pnpm.sh): prefer NVM_PNPM_* from .env;
 # API_HEALTH_* nvm vars are legacy aliases only.
@@ -70,11 +120,173 @@ hc_ok() {
   fi
 }
 
+# --- PM2 daemon placement (see the systemd note in the header) ---
+
+pm2_daemon_pid() {
+  local pidfile="${PM2_HOME:-$HOME/.pm2}/pm2.pid" pid
+  [[ -r "$pidfile" ]] || return 1
+  pid="$(cat "$pidfile" 2>/dev/null)" || return 1
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s' "$pid"
+}
+
+# cgroup path of a pid (systemd unified hierarchy), empty when unavailable.
+proc_cgroup() {
+  local pid="$1"
+  [[ -r "/proc/$pid/cgroup" ]] || return 0
+  awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null || true
+}
+
+# Resolve a directly executable pm2 plus the PATH that finds its node. systemd-run
+# needs a real binary, and nvm_pnpm is a shell function that may wrap
+# `nvm exec <ver> pnpm`. Neither command here runs pm2, so this does not spawn the
+# daemon before we have placed it.
+pm2_exec_env() {
+  # `command -v pm2` under pnpm answers "./node_modules/.bin/pm2" - a relative
+  # path, which systemd-run rejects outright. Absolutise it here.
+  nvm_pnpm exec bash -c '
+    p="$(command -v pm2)" || exit 1
+    [[ "$p" == /* ]] || p="$PWD/${p#./}"
+    printf "%s\n%s\n" "$p" "$PATH"
+  ' 2>/dev/null || true
+}
+
+# Start the PM2 God daemon inside its own transient systemd scope, so it lives in
+# a different cgroup than this (Type=oneshot) job and is not reaped when we exit.
+# Ordering matters: the PM2 CLI auto-spawns the daemon on ANY command, `pm2 status`
+# included, so this must run before every other pm2 invocation.
+ensure_pm2_daemon() {
+  if [[ "${API_HEALTH_PM2_SCOPE:-1}" == "0" ]]; then
+    return 0
+  fi
+  # Already running: it either survived, or a prior run placed it correctly.
+  if pm2_daemon_pid >/dev/null; then
+    return 0
+  fi
+  if ! command -v systemd-run >/dev/null 2>&1; then
+    return 0
+  fi
+
+  export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
+    return 0
+  fi
+
+  local resolved pm2_bin scope_path
+  resolved="$(pm2_exec_env)"
+  pm2_bin="$(printf '%s\n' "$resolved" | sed -n '1p')"
+  scope_path="$(printf '%s\n' "$resolved" | sed -n '2p')"
+  # systemd-run needs an absolute, executable path; anything else is a silent no-op.
+  if [[ "$pm2_bin" != /* || ! -x "$pm2_bin" ]]; then
+    log_echo "WARN: could not resolve a pm2 binary for systemd-run; PM2 may be reaped when this job exits"
+    return 0
+  fi
+
+  # Preferred: a scope. --scope, not --service, because the command is forked
+  # from here and so inherits PM2_HOME and the PATH set below for free; a
+  # --service unit starts from systemd's own environment and loses all of it.
+  # --collect reaps the scope once it is empty; the scope itself stays alive as
+  # long as the daemon holds a process in it.
+  if PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
+    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1; then
+    log_echo "PM2 daemon started in its own systemd scope"
+    return 0
+  fi
+
+  # Fallback: a transient unit. A scope has to migrate an already-running PID
+  # (systemd-run's own) into the new cgroup, and a host that restricts cgroup
+  # delegation to the user manager refuses that outright:
+  #   Failed to add PIDs to scope's control group: Permission denied
+  # `--unit=` has systemd fork the process directly into the new cgroup, so there
+  # is nothing to move. Two costs, both handled here: the environment does not
+  # come along (hence --setenv), and `pm2 ping` exits once the daemon is up, so
+  # the unit needs KillMode=process + RemainAfterExit so that going inactive does
+  # not take the daemon we just spawned down with it.
+  systemctl --user reset-failed ac-api-pm2-daemon.service >/dev/null 2>&1 || true
+  if systemd-run --user --unit=ac-api-pm2-daemon --quiet \
+    --property=KillMode=process \
+    --property=RemainAfterExit=yes \
+    --setenv=PATH="${scope_path:-$PATH}" \
+    --setenv=PM2_HOME="$PM2_HOME" \
+    --setenv=HOME="$HOME" \
+    -- "$pm2_bin" ping >/dev/null 2>&1; then
+    log_echo "PM2 daemon started in its own systemd unit (scope was refused)"
+    return 0
+  fi
+
+  log_echo "WARN: systemd-run scope and unit both failed; PM2 may be reaped when this job exits"
+}
+
+# Warn when the daemon shares our cgroup, which means systemd will kill it the
+# moment this script returns. Purely diagnostic, but this is the exact condition
+# that let a green health check sit on top of a dead service.
+warn_if_pm2_shares_our_cgroup() {
+  local pid ours theirs
+  pid="$(pm2_daemon_pid)" || return 0
+  ours="$(proc_cgroup "$$")"
+  theirs="$(proc_cgroup "$pid")"
+  [[ -n "$ours" && -n "$theirs" ]] || return 0
+  if [[ "$ours" == "$theirs" ]]; then
+    log_echo "WARN: PM2 daemon (pid $pid) is in this job's cgroup ($ours)."
+    log_echo "      A Type=oneshot unit will SIGTERM it when this script exits."
+  fi
+}
+
+# --- HTTP probe ---
+
+# Sets PROBE_VERDICT. See scripts/lib/api-probe.sh for what each verdict means.
+PROBE_VERDICT="SKIPPED"
+run_probe() {
+  local label="$1" result code detail
+  if [[ -z "$PROBE_URL" ]]; then
+    PROBE_VERDICT="SKIPPED"
+    log_echo "SKIP: HTTP probe disabled (set API_HEALTH_PROBE_URL to enable)"
+    return 0
+  fi
+
+  result="$(api_probe "$PROBE_URL" "$PROBE_MARKER" "$PROBE_TIMEOUT")"
+  PROBE_VERDICT="${result%% *}"
+  result="${result#* }"
+  code="${result%% *}"
+  detail="${result#* }"
+
+  case "$PROBE_VERDICT" in
+    PASS)
+      log_echo "OK: $label probe served the expected payload from $PROBE_URL (http=$code)"
+      ;;
+    FAIL)
+      # The 200 here is the trap: something answers, but it is not a working API.
+      log_echo "ERROR: $label probe - $PROBE_URL answered http=$code but the body did not contain '$PROBE_MARKER': $detail"
+      ;;
+    DOWN)
+      log_echo "ERROR: $label probe - nothing healthy answered at $PROBE_URL (http=$code): $detail"
+      ;;
+    INCONCLUSIVE)
+      log_echo "WARN: $label probe rate limited (http=$code); treating as inconclusive: $detail"
+      ;;
+    BAD_REQUEST)
+      log_echo "ERROR: $label probe rejected (http=$code) - check API_HEALTH_PROBE_URL and API_HEALTH_PROBE_MARKER: $detail"
+      ;;
+  esac
+}
+
+pm2_is_online() {
+  local output
+  output="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
+  printf '%s\n' "$output" >> "$LOG_FILE"
+  PM2_OUTPUT="$output"
+  grep -q "online" <<<"$output"
+}
+
+# --- main ---
+
 log_echo "=== API Health Monitor Started ==="
 log_echo "Project: $PROJECT_DIR"
 log_echo "App: $APP_NAME"
 log_echo "Log file: $LOG_FILE"
 log_echo "PM2_HOME: $PM2_HOME"
+log_echo "Probe: ${PROBE_URL:-<disabled>}"
 
 if [[ ! -d "$PROJECT_DIR" ]]; then
   msg="api-health failed ($(date -u +"%Y-%m-%dT%H:%M:%SZ"))\nproject_dir_missing=$PROJECT_DIR\npm2_home=$PM2_HOME"
@@ -103,40 +315,87 @@ else
   log_echo "pnpm: $(command -v pnpm)"
 fi
 
-PM2_OUTPUT="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
-echo "$PM2_OUTPUT" >> "$LOG_FILE"
+# MUST come before any other pm2 command - see the systemd note in the header.
+ensure_pm2_daemon
 
-if echo "$PM2_OUTPUT" | grep -q "online"; then
-  log_echo "OK: $APP_NAME is online"
-  SERVICE_ONLINE=1
+PM2_OUTPUT=""
+pm2_online=false
+if pm2_is_online; then
+  log_echo "OK: $APP_NAME is online in PM2"
+  pm2_online=true
 else
-  log_echo "WARN: $APP_NAME is not online; attempting start/restart"
-  START_OUTPUT="$(nvm_pnpm api:start 2>&1 || true)"
-  echo "$START_OUTPUT" >> "$LOG_FILE"
-  sleep 5
-  RECHECK_OUTPUT="$(nvm_pnpm exec pm2 status "$APP_NAME" --no-color 2>&1 || true)"
-  echo "$RECHECK_OUTPUT" >> "$LOG_FILE"
+  log_echo "WARN: $APP_NAME is not online in PM2"
+fi
 
-  if echo "$RECHECK_OUTPUT" | grep -q "online"; then
-    log_echo "OK: $APP_NAME is online after restart"
-    SERVICE_ONLINE=1
-  else
+run_probe "initial"
+
+# Restart only for problems a restart can actually fix. A rate-limited probe
+# proves nothing, and a misconfigured probe URL is not the API's fault - bouncing
+# the service on those just adds an outage to an outage.
+needs_restart=false
+if [[ "$pm2_online" == false ]]; then
+  needs_restart=true
+elif [[ "$PROBE_VERDICT" == "FAIL" || "$PROBE_VERDICT" == "DOWN" ]]; then
+  log_echo "PM2 reports $APP_NAME online but it is not serving; restarting anyway."
+  needs_restart=true
+fi
+
+if [[ "$needs_restart" == true ]]; then
+  log_echo "Attempting to start/restart $APP_NAME..."
+  START_OUTPUT="$(nvm_pnpm api:start 2>&1 || true)"
+  printf '%s\n' "$START_OUTPUT" >> "$LOG_FILE"
+
+  pm2_online=false
+  for ((attempt = 1; attempt <= START_ATTEMPTS; attempt++)); do
+    sleep "$START_RETRY_SLEEP"
+    if pm2_is_online; then
+      pm2_online=true
+      run_probe "post-restart"
+      # A freshly started Fastify can be listed online a beat before it binds the
+      # port, so keep probing rather than failing on the first refused connection.
+      if [[ "$PROBE_VERDICT" != "FAIL" && "$PROBE_VERDICT" != "DOWN" ]]; then
+        log_echo "OK: $APP_NAME recovered after $((attempt * START_RETRY_SLEEP))s"
+        break
+      fi
+    fi
+    log_echo "  ... attempt $attempt/$START_ATTEMPTS: not healthy yet"
+  done
+
+  if [[ "$pm2_online" == false ]]; then
     log_echo "ERROR: $APP_NAME failed to become online"
-    SERVICE_ONLINE=0
   fi
 fi
 
-if [[ "$SERVICE_ONLINE" -eq 1 ]]; then
-  hc_ok "api-health ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") app=$APP_NAME"
-  log_echo "OK: API health ping sent"
+# Green requires PM2 online AND a probe that did not fail. INCONCLUSIVE and
+# SKIPPED stay green: they carry no evidence of an outage, and flapping the alert
+# on a rate limit trains people to ignore it. BAD_REQUEST is red on purpose - a
+# monitor that cannot verify anything must not claim the service is healthy.
+service_online=false
+if [[ "$pm2_online" == true ]]; then
+  case "$PROBE_VERDICT" in
+    PASS | INCONCLUSIVE | SKIPPED) service_online=true ;;
+  esac
+fi
+
+status_line="pm2_online=$pm2_online probe=$PROBE_VERDICT restart_attempted=$needs_restart"
+
+# Diagnose the cgroup trap before we exit, whichever way this went.
+warn_if_pm2_shares_our_cgroup
+
+if [[ "$service_online" == true ]]; then
+  hc_ok "api-health ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") app=$APP_NAME $status_line"
+  log_echo "OK: API health ping sent ($status_line)"
 else
   body=$(
     printf "api-health failed (%s)\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     printf "app=%s\nproject_dir=%s\npm2_home=%s\n" "$APP_NAME" "$PROJECT_DIR" "$PM2_HOME"
-    printf "pm2_status_snippet=%s\n" "$(echo "$PM2_OUTPUT" | tr '\n' ' ' | head -c 400)"
+    printf "%s\nprobe_url=%s\n" "$status_line" "${PROBE_URL:-<disabled>}"
+    printf "pm2_status_snippet=%s\n" "$(printf '%s' "$PM2_OUTPUT" | tr '\n' ' ' | head -c 400)"
   )
   hc_fail "$body"
-  log_echo "WARN: Service not online; sent fail ping"
+  log_echo "WARN: Service not healthy; sent fail ping ($status_line)"
+  log_echo "=== API Health Monitor Completed ==="
+  trim_log
   exit 1
 fi
 

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -138,6 +138,20 @@ proc_cgroup() {
   awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null || true
 }
 
+# 0 when a PM2 daemon is running in a cgroup that is NOT this job's - i.e. it
+# will survive our exit. When cgroup info is unavailable (no /proc, e.g. macOS)
+# fall back to "is it running at all" rather than reporting a false failure.
+pm2_daemon_placed_ok() {
+  local pid ours theirs
+  pid="$(pm2_daemon_pid)" || return 1
+  ours="$(proc_cgroup "$$")"
+  theirs="$(proc_cgroup "$pid")"
+  if [[ -z "$ours" || -z "$theirs" ]]; then
+    return 0
+  fi
+  [[ "$ours" != "$theirs" ]]
+}
+
 # Resolve a directly executable pm2 plus the PATH that finds its node. systemd-run
 # needs a real binary, and nvm_pnpm is a shell function that may wrap
 # `nvm exec <ver> pnpm`. Neither command here runs pm2, so this does not spawn the
@@ -183,39 +197,49 @@ ensure_pm2_daemon() {
     return 0
   fi
 
-  # Preferred: a scope. --scope, not --service, because the command is forked
+  # Attempt 1: a scope. --scope, not --service, because the command is forked
   # from here and so inherits PM2_HOME and the PATH set below for free; a
   # --service unit starts from systemd's own environment and loses all of it.
   # --collect reaps the scope once it is empty; the scope itself stays alive as
   # long as the daemon holds a process in it.
-  if PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
-    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1; then
+  PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
+    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1 || true
+  if pm2_daemon_placed_ok; then
     log_echo "PM2 daemon started in its own systemd scope"
     return 0
   fi
 
-  # Fallback: a transient unit. A scope has to migrate an already-running PID
-  # (systemd-run's own) into the new cgroup, and a host that restricts cgroup
-  # delegation to the user manager refuses that outright:
+  # A scope has to migrate an already-running PID (systemd-run's own) into the
+  # new cgroup, and a host that restricts cgroup delegation to the user manager
+  # refuses that:
   #   Failed to add PIDs to scope's control group: Permission denied
-  # `--unit=` has systemd fork the process directly into the new cgroup, so there
-  # is nothing to move. Two costs, both handled here: the environment does not
-  # come along (hence --setenv), and `pm2 ping` exits once the daemon is up, so
-  # the unit needs KillMode=process + RemainAfterExit so that going inactive does
-  # not take the daemon we just spawned down with it.
+  # This is why the check above asks where the daemon actually landed instead of
+  # trusting the exit status: the scope can fail QUIETLY, having already run
+  # `pm2 ping` and spawned the daemon into OUR cgroup. Clear it out, or the
+  # retry below just pings that misplaced daemon and declares success. Safe to
+  # kill here: we only reach this point when no daemon was running on entry, so
+  # nothing is parented to it yet.
+  nvm_pnpm exec pm2 kill >/dev/null 2>&1 || true
+
+  # Attempt 2: a transient unit. `--unit=` has systemd fork the process directly
+  # into the new cgroup, so there is nothing to migrate. Two costs, both handled
+  # here: the environment does not come along (hence --setenv), and `pm2 ping`
+  # exits once the daemon is up, so the unit needs KillMode=process plus
+  # RemainAfterExit so that going inactive does not take the daemon with it.
   systemctl --user reset-failed ac-api-pm2-daemon.service >/dev/null 2>&1 || true
-  if systemd-run --user --unit=ac-api-pm2-daemon --quiet \
+  systemd-run --user --unit=ac-api-pm2-daemon --quiet \
     --property=KillMode=process \
     --property=RemainAfterExit=yes \
     --setenv=PATH="${scope_path:-$PATH}" \
     --setenv=PM2_HOME="$PM2_HOME" \
     --setenv=HOME="$HOME" \
-    -- "$pm2_bin" ping >/dev/null 2>&1; then
+    -- "$pm2_bin" ping >/dev/null 2>&1 || true
+  if pm2_daemon_placed_ok; then
     log_echo "PM2 daemon started in its own systemd unit (scope was refused)"
     return 0
   fi
 
-  log_echo "WARN: systemd-run scope and unit both failed; PM2 may be reaped when this job exits"
+  log_echo "WARN: could not place the PM2 daemon outside this job's cgroup; it may be reaped when this job exits"
 }
 
 # Warn when the daemon shares our cgroup, which means systemd will kill it the

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -29,8 +29,9 @@
 # command, `pm2 status` included, so a plain first call adopts the daemon (and
 # ac-api with it) into the doomed cgroup: the check restarts the API, reports
 # green, and then kills it on the way out. ensure_pm2_daemon() below places the
-# daemon in its own cgroup first - a transient scope where that is permitted, a
-# transient unit where cgroup delegation is restricted and a scope is refused.
+# daemon in its own cgroup first: a transient unit, which works here because
+# systemd forks straight into the new cgroup, falling back to a transient scope
+# on hosts that permit migrating a PID into one.
 # See the comments on that function, and scripts/launch-listmonk.sh for the same
 # problem on the newsletter host.
 #
@@ -40,7 +41,7 @@
 #   API_APP_NAME               — PM2 process name (default: ac-api)
 #   API_HEALTHCHECK_PING_URL   — Healthchecks.io ping URL
 #   API_HEALTH_PM2_HOME        — PM2 state dir (default: <repo>/.pm2)
-#   API_HEALTH_PM2_SCOPE       — 0 to skip the systemd scope described above
+#   API_HEALTH_PM2_SCOPE       — 0 to skip the cgroup isolation described above
 #   API_HEALTH_PROBE_URL       — HTTP probe target; empty disables the probe
 #   API_HEALTH_PROBE_MARKER    — string the probe body must contain
 #   API_HEALTH_PROBE_TIMEOUT   — seconds for the probe request (default 10)
@@ -197,35 +198,17 @@ ensure_pm2_daemon() {
     return 0
   fi
 
-  # Attempt 1: a scope. --scope, not --service, because the command is forked
-  # from here and so inherits PM2_HOME and the PATH set below for free; a
-  # --service unit starts from systemd's own environment and loses all of it.
-  # --collect reaps the scope once it is empty; the scope itself stays alive as
-  # long as the daemon holds a process in it.
-  PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
-    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1 || true
-  if pm2_daemon_placed_ok; then
-    log_echo "PM2 daemon started in its own systemd scope"
-    return 0
-  fi
-
-  # A scope has to migrate an already-running PID (systemd-run's own) into the
-  # new cgroup, and a host that restricts cgroup delegation to the user manager
-  # refuses that:
-  #   Failed to add PIDs to scope's control group: Permission denied
-  # This is why the check above asks where the daemon actually landed instead of
-  # trusting the exit status: the scope can fail QUIETLY, having already run
-  # `pm2 ping` and spawned the daemon into OUR cgroup. Clear it out, or the
-  # retry below just pings that misplaced daemon and declares success. Safe to
-  # kill here: we only reach this point when no daemon was running on entry, so
-  # nothing is parented to it yet.
-  nvm_pnpm exec pm2 kill >/dev/null 2>&1 || true
-
-  # Attempt 2: a transient unit. `--unit=` has systemd fork the process directly
-  # into the new cgroup, so there is nothing to migrate. Two costs, both handled
-  # here: the environment does not come along (hence --setenv), and `pm2 ping`
-  # exits once the daemon is up, so the unit needs KillMode=process plus
-  # RemainAfterExit so that going inactive does not take the daemon with it.
+  # Attempt 1: a transient UNIT. This is the one that works on May First:
+  # `--unit=` has systemd fork the process directly into the new cgroup, so no
+  # PID has to be migrated. Verified on weborigin002 (2026-09-07).
+  #
+  # Two costs, both handled here. The environment does NOT come along the way it
+  # would with a scope, hence --setenv for the PATH that finds node plus
+  # PM2_HOME and HOME (pm2 derives its default state dir from HOME). And
+  # `pm2 ping` exits as soon as the daemon is up, so the unit needs
+  # KillMode=process plus RemainAfterExit: without them the unit going inactive
+  # takes the daemon we just spawned down with it, which is the very thing this
+  # function exists to prevent.
   systemctl --user reset-failed ac-api-pm2-daemon.service >/dev/null 2>&1 || true
   systemd-run --user --unit=ac-api-pm2-daemon --quiet \
     --property=KillMode=process \
@@ -235,7 +218,31 @@ ensure_pm2_daemon() {
     --setenv=HOME="$HOME" \
     -- "$pm2_bin" ping >/dev/null 2>&1 || true
   if pm2_daemon_placed_ok; then
-    log_echo "PM2 daemon started in its own systemd unit (scope was refused)"
+    log_echo "PM2 daemon started in its own systemd unit"
+    return 0
+  fi
+
+  # Clear out a daemon that got spawned but landed in our cgroup anyway, or the
+  # next attempt just pings that misplaced daemon and declares success. Safe to
+  # kill here: we only reach this point when no daemon was running on entry, so
+  # nothing is parented to it yet.
+  nvm_pnpm exec pm2 kill >/dev/null 2>&1 || true
+
+  # Attempt 2: a scope. Tried second, not first, because on these hosts cgroup
+  # delegation to the user manager is restricted and a scope cannot migrate an
+  # already-running PID (systemd-run's own) into the new cgroup:
+  #   test-scope-probe.scope: Couldn't move process ... Input/output error
+  #   test-scope-probe.scope: Failed to add PIDs to scope's control group: Permission denied
+  # Worse, it fails QUIETLY - `pm2 ping` has already run and left the daemon in
+  # the caller's cgroup - which is why every attempt here is judged by
+  # pm2_daemon_placed_ok() and never by systemd-run's exit status. Kept as a
+  # fallback for hosts that do allow it, where a scope is the better mechanism:
+  # the command is forked from here, so it inherits our whole environment and
+  # needs no --setenv at all, and --collect reaps the scope once it empties.
+  PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
+    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1 || true
+  if pm2_daemon_placed_ok; then
+    log_echo "PM2 daemon started in its own systemd scope"
     return 0
   fi
 

--- a/scripts/healthcheck-api.sh
+++ b/scripts/healthcheck-api.sh
@@ -31,7 +31,9 @@
 # green, and then kills it on the way out. ensure_pm2_daemon() below places the
 # daemon in its own cgroup first: a transient unit, which works here because
 # systemd forks straight into the new cgroup, falling back to a transient scope
-# on hosts that permit migrating a PID into one.
+# on hosts that permit migrating a PID into one. If neither works the check
+# reports RED even when the API is answering - it is answering now and will be
+# dead in a second, and saying "healthy" to that is the original bug.
 # See the comments on that function, and scripts/launch-listmonk.sh for the same
 # problem on the newsletter host.
 #
@@ -161,58 +163,81 @@ pm2_daemon_placed_ok() {
   [[ "$ours" != "$theirs" ]]
 }
 
-# Resolve a directly executable pm2 plus the PATH that finds its node. systemd-run
-# needs a real binary, and nvm_pnpm is a shell function that may wrap
-# `nvm exec <ver> pnpm`. Neither command here runs pm2, so this does not spawn the
-# daemon before we have placed it.
-pm2_exec_env() {
-  # `command -v pm2` under pnpm answers "./node_modules/.bin/pm2" - a relative
-  # path, which systemd-run rejects outright. Absolutise it here.
-  nvm_pnpm exec bash -c '
-    p="$(command -v pm2)" || exit 1
-    [[ "$p" == /* ]] || p="$PWD/${p#./}"
-    printf "%s\n%s\n" "$p" "$PATH"
-  ' 2>/dev/null || true
+# Bring a PM2 daemon up, as an argv systemd-run can exec. pm2 only reaches us
+# through the nvm_pnpm shell function, and shell functions do not survive an
+# exec, so the child re-sources the helper rather than us resolving a pm2 binary
+# and its PATH by hand (`command -v pm2` under pnpm answers a *relative* path,
+# which systemd-run rejects outright). Approach borrowed from the parallel work
+# on dev/api-healthcheck-systemd-fix.
+PM2_PING_ARGV=(
+  /bin/bash -c 'set -euo pipefail
+cd "$NVM_PNPM_PROJECT_DIR"
+source "$NVM_PNPM_PROJECT_DIR/scripts/lib/nvm-pnpm.sh"
+nvm_pnpm_init
+nvm_pnpm exec pm2 ping'
+)
+
+# A scope inherits our exported environment; a transient unit inherits nothing,
+# so everything nvm_pnpm_init and pm2 need has to be handed over explicitly.
+pm2_unit_setenv_args() {
+  printf '%s\n' \
+    "--setenv=HOME=$HOME" \
+    "--setenv=PATH=$PATH" \
+    "--setenv=PM2_HOME=$PM2_HOME" \
+    "--setenv=NVM_PNPM_PROJECT_DIR=$NVM_PNPM_PROJECT_DIR" \
+    "--setenv=NVM_PNPM_USE_NVM=$NVM_PNPM_USE_NVM" \
+    "--setenv=NVM_PNPM_NVM_DIR=$NVM_PNPM_NVM_DIR" \
+    "--setenv=NVM_PNPM_NODE_VERSION=$NVM_PNPM_NODE_VERSION" \
+    "--setenv=NVM_PNPM_PATH_EXTRA=$NVM_PNPM_PATH_EXTRA"
 }
 
-# Start the PM2 God daemon inside its own transient systemd scope, so it lives in
-# a different cgroup than this (Type=oneshot) job and is not reaped when we exit.
-# Ordering matters: the PM2 CLI auto-spawns the daemon on ANY command, `pm2 status`
-# included, so this must run before every other pm2 invocation.
+# Place the PM2 God daemon in a cgroup that outlives this (Type=oneshot) job.
+# Ordering matters: the PM2 CLI auto-spawns the daemon on ANY command, `pm2
+# status` included, so this must run before every other pm2 invocation.
+#
+# Sets PM2_DAEMON_PLACED to one of:
+#   ok  - the daemon is in a cgroup that is not ours, so it survives our exit
+#   na  - isolation not applicable (disabled by config, or no systemd user
+#         session - dev machines and non-systemd hosts run this way by design)
+#   bad - we could not place it; it will be reaped when this script exits
+PM2_DAEMON_PLACED="na"
 ensure_pm2_daemon() {
   if [[ "${API_HEALTH_PM2_SCOPE:-1}" == "0" ]]; then
-    return 0
-  fi
-  # Already running: it either survived, or a prior run placed it correctly.
-  if pm2_daemon_pid >/dev/null; then
+    PM2_DAEMON_PLACED="na"
     return 0
   fi
   if ! command -v systemd-run >/dev/null 2>&1; then
+    log_echo "systemd-run unavailable; PM2 daemon will start in the caller's cgroup"
+    PM2_DAEMON_PLACED="na"
     return 0
   fi
 
   export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
   if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
+    log_echo "no systemd user session at $XDG_RUNTIME_DIR; PM2 daemon will start in the caller's cgroup"
+    PM2_DAEMON_PLACED="na"
     return 0
   fi
 
-  local resolved pm2_bin scope_path
-  resolved="$(pm2_exec_env)"
-  pm2_bin="$(printf '%s\n' "$resolved" | sed -n '1p')"
-  scope_path="$(printf '%s\n' "$resolved" | sed -n '2p')"
-  # systemd-run needs an absolute, executable path; anything else is a silent no-op.
-  if [[ "$pm2_bin" != /* || ! -x "$pm2_bin" ]]; then
-    log_echo "WARN: could not resolve a pm2 binary for systemd-run; PM2 may be reaped when this job exits"
-    return 0
+  # Already running: it either survived, or a prior run placed it. Still has to
+  # be judged on where it actually is - a daemon adopted into an earlier job's
+  # cgroup is exactly the state we must not report green on.
+  if pm2_daemon_pid >/dev/null; then
+    if pm2_daemon_placed_ok; then
+      PM2_DAEMON_PLACED="ok"
+      return 0
+    fi
+    log_echo "WARN: existing PM2 daemon shares this job's cgroup; restarting it somewhere safe"
+    nvm_pnpm exec pm2 kill >/dev/null 2>&1 </dev/null || true
   fi
+
+  local -a setenv_args=()
+  while IFS= read -r arg; do setenv_args+=("$arg"); done < <(pm2_unit_setenv_args)
 
   # Attempt 1: a transient UNIT. This is the one that works on May First:
   # `--unit=` has systemd fork the process directly into the new cgroup, so no
   # PID has to be migrated. Verified on weborigin002 (2026-09-07).
   #
-  # Two costs, both handled here. The environment does NOT come along the way it
-  # would with a scope, hence --setenv for the PATH that finds node plus
-  # PM2_HOME and HOME (pm2 derives its default state dir from HOME). And
   # `pm2 ping` exits as soon as the daemon is up, so the unit needs
   # KillMode=process plus RemainAfterExit: without them the unit going inactive
   # takes the daemon we just spawned down with it, which is the very thing this
@@ -221,55 +246,38 @@ ensure_pm2_daemon() {
   systemd-run --user --unit=ac-api-pm2-daemon --quiet \
     --property=KillMode=process \
     --property=RemainAfterExit=yes \
-    --setenv=PATH="${scope_path:-$PATH}" \
-    --setenv=PM2_HOME="$PM2_HOME" \
-    --setenv=HOME="$HOME" \
-    -- "$pm2_bin" ping >/dev/null 2>&1 || true
+    "${setenv_args[@]}" \
+    -- "${PM2_PING_ARGV[@]}" >/dev/null 2>&1 || true
   if pm2_daemon_placed_ok; then
     log_echo "PM2 daemon started in its own systemd unit"
+    PM2_DAEMON_PLACED="ok"
     return 0
   fi
 
   # Clear out a daemon that got spawned but landed in our cgroup anyway, or the
-  # next attempt just pings that misplaced daemon and declares success. Safe to
-  # kill here: we only reach this point when no daemon was running on entry, so
-  # nothing is parented to it yet.
+  # next attempt just pings that misplaced daemon and declares success.
   nvm_pnpm exec pm2 kill >/dev/null 2>&1 </dev/null || true
 
   # Attempt 2: a scope. Tried second, not first, because on these hosts cgroup
   # delegation to the user manager is restricted and a scope cannot migrate an
   # already-running PID (systemd-run's own) into the new cgroup:
-  #   test-scope-probe.scope: Couldn't move process ... Input/output error
-  #   test-scope-probe.scope: Failed to add PIDs to scope's control group: Permission denied
+  #   Couldn't move process ... Input/output error
+  #   Failed to add PIDs to scope's control group: Permission denied
   # Worse, it fails QUIETLY - `pm2 ping` has already run and left the daemon in
   # the caller's cgroup - which is why every attempt here is judged by
-  # pm2_daemon_placed_ok() and never by systemd-run's exit status. Kept as a
-  # fallback for hosts that do allow it, where a scope is the better mechanism:
-  # the command is forked from here, so it inherits our whole environment and
-  # needs no --setenv at all, and --collect reaps the scope once it empties.
-  PATH="${scope_path:-$PATH}" systemd-run --user --scope --quiet --collect \
-    --unit="ac-api-pm2-daemon-$$" -- "$pm2_bin" ping >/dev/null 2>&1 || true
+  # pm2_daemon_placed_ok() and never by systemd-run's exit status. Kept for
+  # hosts that do allow it, where a scope is the better mechanism: it inherits
+  # our whole environment, and --collect reaps it once it empties.
+  systemd-run --user --scope --quiet --collect \
+    --unit="ac-api-pm2-daemon-$$" -- "${PM2_PING_ARGV[@]}" >/dev/null 2>&1 || true
   if pm2_daemon_placed_ok; then
     log_echo "PM2 daemon started in its own systemd scope"
+    PM2_DAEMON_PLACED="ok"
     return 0
   fi
 
-  log_echo "WARN: could not place the PM2 daemon outside this job's cgroup; it may be reaped when this job exits"
-}
-
-# Warn when the daemon shares our cgroup, which means systemd will kill it the
-# moment this script returns. Purely diagnostic, but this is the exact condition
-# that let a green health check sit on top of a dead service.
-warn_if_pm2_shares_our_cgroup() {
-  local pid ours theirs
-  pid="$(pm2_daemon_pid)" || return 0
-  ours="$(proc_cgroup "$$")"
-  theirs="$(proc_cgroup "$pid")"
-  [[ -n "$ours" && -n "$theirs" ]] || return 0
-  if [[ "$ours" == "$theirs" ]]; then
-    log_echo "WARN: PM2 daemon (pid $pid) is in this job's cgroup ($ours)."
-    log_echo "      A Type=oneshot unit will SIGTERM it when this script exits."
-  fi
+  log_echo "ERROR: could not place the PM2 daemon outside this job's cgroup; it will be reaped when this script exits"
+  PM2_DAEMON_PLACED="bad"
 }
 
 # --- HTTP probe ---
@@ -415,10 +423,16 @@ if [[ "$pm2_online" == true ]]; then
   esac
 fi
 
-status_line="pm2_online=$pm2_online probe=$PROBE_VERDICT restart_attempted=$needs_restart"
+# A green probe is NOT enough when the daemon could not be placed: the API is
+# answering right now but is about to be reaped on our way out, which is exactly
+# the state that reported healthy every five minutes while the site served 503s.
+# Report the truth instead of the snapshot.
+if [[ "$service_online" == true && "$PM2_DAEMON_PLACED" == "bad" ]]; then
+  log_echo "WARN: API is answering, but its PM2 daemon shares this job's cgroup and will be killed on exit"
+  service_online=false
+fi
 
-# Diagnose the cgroup trap before we exit, whichever way this went.
-warn_if_pm2_shares_our_cgroup
+status_line="pm2_online=$pm2_online probe=$PROBE_VERDICT daemon_placed=$PM2_DAEMON_PLACED restart_attempted=$needs_restart"
 
 if [[ "$service_online" == true ]]; then
   hc_ok "api-health ok $(date -u +"%Y-%m-%dT%H:%M:%SZ") app=$APP_NAME $status_line"

--- a/scripts/healthcheck-canary.mjs
+++ b/scripts/healthcheck-canary.mjs
@@ -36,12 +36,19 @@ if (!PING_URL) {
   process.exit(2);
 }
 
-// A Healthchecks ping URL is a bearer credential: anyone holding it can forge
-// OK pings and silence the check. This script's output is redirected to
-// include/logs/healthcheck-canary.log, so logging the raw URL wrote the UUID to
-// disk in cleartext. Log only the endpoint being pinged.
+// A Healthchecks ping URL is a credential, and this script's output is captured
+// to a log file, so logging the raw URL persisted it in cleartext. Log only the
+// endpoint being pinged.
 function pingLabel(endpoint) {
   return `canary ping${endpoint ? ` /${endpoint}` : ''}`;
+}
+
+// A thrown fetch error can carry the request URL in its message depending on the
+// runtime and failure mode. Strip any occurrence before it reaches a log file.
+function safeErrorMessage(err) {
+  const message = String(err?.message ?? err ?? 'unknown error');
+  if (!PING_URL) return message;
+  return message.split(PING_URL).join('[REDACTED]');
 }
 
 async function ping(endpoint, body) {
@@ -61,7 +68,7 @@ async function ping(endpoint, body) {
     console.log(`${label} ok`);
     return true;
   } catch (err) {
-    console.error(`${label} failed: ${err.message}`);
+    console.error(`${label} failed: ${safeErrorMessage(err)}`);
     return false;
   }
 }

--- a/scripts/healthcheck-canary.mjs
+++ b/scripts/healthcheck-canary.mjs
@@ -36,8 +36,17 @@ if (!PING_URL) {
   process.exit(2);
 }
 
+// A Healthchecks ping URL is a bearer credential: anyone holding it can forge
+// OK pings and silence the check. This script's output is redirected to
+// include/logs/healthcheck-canary.log, so logging the raw URL wrote the UUID to
+// disk in cleartext. Log only the endpoint being pinged.
+function pingLabel(endpoint) {
+  return `canary ping${endpoint ? ` /${endpoint}` : ''}`;
+}
+
 async function ping(endpoint, body) {
   const url = endpoint ? `${PING_URL}/${endpoint}` : PING_URL;
+  const label = pingLabel(endpoint);
   try {
     const res = await fetch(url, {
       method: 'POST',
@@ -46,13 +55,13 @@ async function ping(endpoint, body) {
       signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) {
-      console.error(`Ping to ${url} returned ${res.status} ${res.statusText}`);
-       return false;
-     }
-     console.log(`Pinged ${url}`);
-     return true;
+      console.error(`${label} returned ${res.status} ${res.statusText}`);
+      return false;
+    }
+    console.log(`${label} ok`);
+    return true;
   } catch (err) {
-    console.error(`Ping to ${url} failed: ${err.message}`);
+    console.error(`${label} failed: ${err.message}`);
     return false;
   }
 }

--- a/scripts/healthcheck-domain.sh
+++ b/scripts/healthcheck-domain.sh
@@ -57,8 +57,11 @@ if command -v whois >/dev/null 2>&1; then
 fi
 
 # 2) Fallback to RDAP over HTTPS (no whois binary/sudo required).
+# rdap.org is a bootstrap/redirect service: it answers 302 pointing at the TLD's
+# authoritative server (.org -> rdap.publicinterestregistry.org), so -L is required.
+# Without it curl returns an empty body and the check fails as expiry_not_found.
 if [[ -z "$expiry_raw" ]]; then
-  rdap_json="$(curl -fsS --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
+  rdap_json="$(curl -fsSL --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
   if [[ -n "$rdap_json" ]]; then
     one_line_json="$(echo "$rdap_json" | tr -d '\n' | tr -d '\r')"
     # Common case: eventAction then eventDate in same event object.

--- a/scripts/healthcheck-domain.sh
+++ b/scripts/healthcheck-domain.sh
@@ -60,8 +60,14 @@ fi
 # rdap.org is a bootstrap/redirect service: it answers 302 pointing at the TLD's
 # authoritative server (.org -> rdap.publicinterestregistry.org), so -L is required.
 # Without it curl returns an empty body and the check fails as expiry_not_found.
+#
+# -L means a third party now chooses where this request lands, so constrain it:
+# --proto-redir =https blocks a downgrade to http or a jump to another scheme,
+# and --max-redirs caps the chain (curl's default is 50). Without these a hijacked
+# rdap.org could point the check at an internal address and get a slice of the
+# response echoed into the could_not_parse_expiry ping body below.
 if [[ -z "$expiry_raw" ]]; then
-  rdap_json="$(curl -fsSL --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
+  rdap_json="$(curl -fsSL --proto-redir =https --max-redirs 3 --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
   if [[ -n "$rdap_json" ]]; then
     one_line_json="$(echo "$rdap_json" | tr -d '\n' | tr -d '\r')"
     # Common case: eventAction then eventDate in same event object.

--- a/scripts/healthcheck-domain.sh
+++ b/scripts/healthcheck-domain.sh
@@ -61,11 +61,10 @@ fi
 # authoritative server (.org -> rdap.publicinterestregistry.org), so -L is required.
 # Without it curl returns an empty body and the check fails as expiry_not_found.
 #
-# -L means a third party now chooses where this request lands, so constrain it:
-# --proto-redir =https blocks a downgrade to http or a jump to another scheme,
-# and --max-redirs caps the chain (curl's default is 50). Without these a hijacked
-# rdap.org could point the check at an internal address and get a slice of the
-# response echoed into the could_not_parse_expiry ping body below.
+# -L means a third party chooses where this request lands, so constrain it:
+# --proto-redir =https keeps the chain on https, and --max-redirs caps its length
+# (curl's default is 50). The response is parsed below and can surface in a ping
+# body, so it should only ever come from where we expect.
 if [[ -z "$expiry_raw" ]]; then
   rdap_json="$(curl -fsSL --proto-redir =https --max-redirs 3 --max-time 15 "https://rdap.org/domain/${DOMAIN_NAME}" 2>/dev/null || true)"
   if [[ -n "$rdap_json" ]]; then

--- a/scripts/healthcheck-site.sh
+++ b/scripts/healthcheck-site.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
-# Cron-driven health check for static site + API.
+# Scheduled health check for the static site.
 # If all checks pass, ping Healthchecks.io.
+#
+# Deliberately does NOT probe the API: an API outage used to fail this check and
+# fire a misleading "main site down" alert. scripts/healthcheck-api.sh owns the
+# API and probes it over HTTP.
 #
 # Setup example:
 #   export HEALTHCHECK_PING_URL="https://hc-ping.com/your-uuid"
@@ -122,11 +126,6 @@ fi
 # News index should resolve.
 if ! curl -fsS --max-time 15 "$SITE_URL/news/" >/dev/null; then
   errors+=("news: curl failed ($SITE_URL/news/)")
-fi
-
-# API liveness endpoint should resolve.
-if ! curl -fsS --max-time 15 "$SITE_URL/api-server/hello" >/dev/null; then
-  errors+=("api: curl failed ($SITE_URL/api-server/hello)")
 fi
 
 if (( ${#errors[@]} > 0 )); then

--- a/scripts/lib/api-probe.sh
+++ b/scripts/lib/api-probe.sh
@@ -15,10 +15,11 @@
 # status code, so Fastify serializes a failure as HTTP 200. Any endpoint in this
 # API can answer 200 while being broken, so the probe asserts on the body.
 #
-# This is the sibling of scripts/lib/listmonk-roundtrip.sh and deliberately not a
-# reuse of it: there, an unreachable site API means "not listmonk's fault, do not
-# restart". Here, an unreachable API is exactly the thing we manage, so it gets
-# its own DOWN verdict that DOES trigger a restart. Same shape, inverted meaning.
+# The listmonk health check has a sibling of this file (lib/listmonk-roundtrip.sh,
+# landing separately) and this is deliberately not a reuse of it: there, an
+# unreachable site API means "not listmonk's fault, do not restart". Here, an
+# unreachable API is exactly the thing we manage, so it gets its own DOWN verdict
+# that DOES trigger a restart. Same shape, inverted meaning.
 
 # classify_api_probe <http_code> <body> <marker>
 #

--- a/scripts/lib/api-probe.sh
+++ b/scripts/lib/api-probe.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# HTTP probe for the ac-api health check.
+# Source this file (do not run standalone):
+#   source "$SCRIPT_DIR/lib/api-probe.sh"
+#
+# Why this exists: `pm2 status ac-api` reporting "online" only proves PM2 has a
+# child process it has not seen exit. It says nothing about whether Fastify bound
+# the port, whether the routes registered, or whether the thing answering on 4321
+# is even our app. The old monitor pinged Healthchecks green on that text alone,
+# so a wedged-but-running API looked perfectly healthy.
+#
+# The trap that makes a status-code-only probe insufficient is visible in
+# api/subscribe.js: the handler RETURNS its result object instead of setting a
+# status code, so Fastify serializes a failure as HTTP 200. Any endpoint in this
+# API can answer 200 while being broken, so the probe asserts on the body.
+#
+# This is the sibling of scripts/lib/listmonk-roundtrip.sh and deliberately not a
+# reuse of it: there, an unreachable site API means "not listmonk's fault, do not
+# restart". Here, an unreachable API is exactly the thing we manage, so it gets
+# its own DOWN verdict that DOES trigger a restart. Same shape, inverted meaning.
+
+# classify_api_probe <http_code> <body> <marker>
+#
+# Echoes exactly one verdict:
+#   PASS         - the API answered and served the expected payload.
+#   FAIL         - something answered on the port with HTTP 200, but not our
+#                  payload: routes failed to register, a handler returned an
+#                  error object, or another process owns the port. Restart.
+#   DOWN         - nothing answered (refused/timeout/DNS), or the API returned
+#                  5xx. This is our process, so it also means restart.
+#   INCONCLUSIVE - rate limited. Proves nothing either way; never restart on it.
+#   BAD_REQUEST  - a 4xx that means the probe itself is pointed at the wrong
+#                  place. Restarting cannot fix a bad API_HEALTH_PROBE_URL, so
+#                  this must stay distinct from DOWN.
+classify_api_probe() {
+  local code="$1" body="${2:-}" marker="${3:-}"
+
+  case "$code" in
+    429) printf 'INCONCLUSIVE'; return 0 ;;
+    400 | 401 | 403 | 404 | 405 | 422) printf 'BAD_REQUEST'; return 0 ;;
+  esac
+
+  # curl writes 000 when it never got an HTTP response at all (connection
+  # refused while PM2 restarts, TLS failure, timeout).
+  if [[ "$code" == "000" ]] || { [[ "$code" =~ ^[0-9]+$ ]] && ((code >= 500)); }; then
+    printf 'DOWN'
+    return 0
+  fi
+
+  if [[ "$code" == "200" ]]; then
+    # Fixed-string containment, not a regex: the marker is operator-supplied via
+    # API_HEALTH_PROBE_MARKER and must not be interpreted as a pattern.
+    if [[ -n "$marker" && "$body" == *"$marker"* ]]; then
+      printf 'PASS'
+    else
+      printf 'FAIL'
+    fi
+    return 0
+  fi
+
+  # Any other 2xx/3xx is not the contract this endpoint documents. Treat it as a
+  # broken app rather than a healthy one - a redirect here usually means we hit a
+  # proxy or an error page instead of Fastify.
+  printf 'FAIL'
+}
+
+# api_probe <url> <marker> [timeout_seconds]
+#
+# Echoes "<verdict> <http_code> <single-line body snippet>".
+# Never returns non-zero: the caller decides what a verdict means.
+api_probe() {
+  local url="$1" marker="$2" timeout="${3:-10}"
+  local response code body
+
+  # -s so a failure body is captured rather than dumped; no -f, because a
+  # non-2xx body is exactly what we need to classify.
+  response="$(curl -s -m "$timeout" -w $'\n%{http_code}' \
+    -H 'Accept: application/json' \
+    "$url" 2>/dev/null || true)"
+
+  code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+  [[ -z "$code" ]] && code="000"
+  # When curl fails outright the response is just the code with no body.
+  [[ "$body" == "$code" ]] && body=""
+
+  printf '%s %s %s' \
+    "$(classify_api_probe "$code" "$body" "$marker")" \
+    "$code" \
+    "$(printf '%s' "$body" | tr -d '\n' | cut -c1-200)"
+}

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -31,25 +31,20 @@ load_env_file() {
 # ---------------------------------------------------------------------------
 # Temp directory
 # ---------------------------------------------------------------------------
-# The web host is shared: /tmp is world-readable and 318 other accounts live on
-# the same box. Anything these scripts stage there — a health-check response
-# body, an image still carrying the EXIF we are about to strip — is readable by
-# all of them. Point TMPDIR at a private directory instead, which mktemp,
-# os.tmpdir() and most tooling follow automatically.
+# Optionally point TMPDIR at a directory owned by this account rather than the
+# system temp dir, so intermediates (response bodies, media being processed) are
+# not left where other local accounts could read them. mktemp, os.tmpdir() and
+# most tooling follow TMPDIR automatically.
 #
-# Resolution order:
-#   1. SCRIPTS_TMPDIR, if set (put it in .env.production to be explicit)
-#   2. $HOME/include/.tmp, if it exists — the convention on the servers
-#   3. otherwise leave TMPDIR alone, so dev machines keep their own default
+# Opt-in only: set SCRIPTS_TMPDIR in the environment that needs it (production
+# does, via .env.production). When it is unset nothing is touched and the system
+# default applies, so dev machines behave exactly as they always have.
 #
 # Called from every exit path below, including the ones that return early: this
-# has to run whether or not an env file was found, and SCRIPTS_TMPDIR may itself
-# come from the file that was just sourced.
+# has to run whether or not an env file was found, and SCRIPTS_TMPDIR normally
+# comes from the file that was just sourced.
 apply_scripts_tmpdir() {
   local dir="${SCRIPTS_TMPDIR:-}"
-  if [[ -z "$dir" && -d "$HOME/include/.tmp" ]]; then
-    dir="$HOME/include/.tmp"
-  fi
   [[ -n "$dir" ]] || return 0
 
   if ! mkdir -p "$dir" 2>/dev/null; then

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -28,10 +28,47 @@ load_env_file() {
   set +a
 }
 
+# ---------------------------------------------------------------------------
+# Temp directory
+# ---------------------------------------------------------------------------
+# The web host is shared: /tmp is world-readable and 318 other accounts live on
+# the same box. Anything these scripts stage there — a health-check response
+# body, an image still carrying the EXIF we are about to strip — is readable by
+# all of them. Point TMPDIR at a private directory instead, which mktemp,
+# os.tmpdir() and most tooling follow automatically.
+#
+# Resolution order:
+#   1. SCRIPTS_TMPDIR, if set (put it in .env.production to be explicit)
+#   2. $HOME/include/.tmp, if it exists — the convention on the servers
+#   3. otherwise leave TMPDIR alone, so dev machines keep their own default
+#
+# Called from every exit path below, including the ones that return early: this
+# has to run whether or not an env file was found, and SCRIPTS_TMPDIR may itself
+# come from the file that was just sourced.
+apply_scripts_tmpdir() {
+  local dir="${SCRIPTS_TMPDIR:-}"
+  if [[ -z "$dir" && -d "$HOME/include/.tmp" ]]; then
+    dir="$HOME/include/.tmp"
+  fi
+  [[ -n "$dir" ]] || return 0
+
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "warning: could not create temp dir $dir; leaving TMPDIR unchanged" >&2
+    return 0
+  fi
+  # 700: the whole point is that other tenants cannot read what lands here.
+  chmod 700 "$dir" 2>/dev/null || true
+  export TMPDIR="$dir"
+  # Some tooling reads TMP/TEMP rather than TMPDIR; keep all three in step.
+  export TMP="$dir"
+  export TEMP="$dir"
+}
+
 if [[ -n "${ENV_FILE:-}" ]]; then
   if [[ -r "$ENV_FILE" ]]; then
     load_env_file "$ENV_FILE"
     export LOADED_ENV_FILE="$ENV_FILE"
+    apply_scripts_tmpdir
     return 0
   fi
   echo "ENV_FILE is set but unreadable: $ENV_FILE" >&2
@@ -42,9 +79,11 @@ for candidate in "$ROOT_DIR/.env.production" "$ROOT_DIR/.env.local" "$ROOT_DIR/.
   if [[ -r "$candidate" ]]; then
     load_env_file "$candidate"
     export LOADED_ENV_FILE="$candidate"
+    apply_scripts_tmpdir
     return 0
   fi
 done
 
 # Not an error: scripts can still run with environment provided externally.
+apply_scripts_tmpdir
 return 0

--- a/scripts/rotate-api-logs.sh
+++ b/scripts/rotate-api-logs.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Trim the PM2 app logs to a short retention window.
+#
+# PM2 does not rotate logs on its own, so include/.pm2/logs grew to 640MB across
+# two files, the oldest entries dating to 2025. Anything logged lives forever
+# until someone notices — which is how ~1,300 subscriber emails ended up sitting
+# on disk for a year. Keep the window short so a future logging mistake has a
+# bounded blast radius.
+#
+# Truncates in place with `: >` rather than deleting: PM2 holds the file open, so
+# unlinking it would leave the daemon writing to an invisible inode until restart.
+#
+# Scheduler example (daily):
+#   /absolute/path/to/repo/scripts/rotate-api-logs.sh
+#
+# Env vars:
+#   API_LOG_DIR          — PM2 log dir (default: $API_HEALTH_PM2_HOME/logs)
+#   API_LOG_RETAIN_HOURS — keep entries newer than this (default: 24)
+#   API_LOG_MAX_BYTES    — truncate outright above this size (default: 52428800)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/load-env.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/log.sh"
+
+init_scripts_file_log "$(resolve_server_log_dir "$PROJECT_DIR")" "rotate-api-logs.log" "$(resolve_server_log_lines_keep)"
+
+PM2_HOME_DIR="${API_HEALTH_PM2_HOME:-$PROJECT_DIR/.pm2}"
+LOG_DIR_TARGET="${API_LOG_DIR:-$PM2_HOME_DIR/logs}"
+RETAIN_HOURS="${API_LOG_RETAIN_HOURS:-24}"
+MAX_BYTES="${API_LOG_MAX_BYTES:-52428800}"
+
+if [[ ! "$RETAIN_HOURS" =~ ^[0-9]+$ ]] || (( RETAIN_HOURS < 1 )); then
+  log_echo "ERROR: API_LOG_RETAIN_HOURS must be an integer >= 1 (got '$RETAIN_HOURS')"
+  exit 1
+fi
+if [[ ! -d "$LOG_DIR_TARGET" ]]; then
+  log_echo "Nothing to do: $LOG_DIR_TARGET does not exist"
+  exit 0
+fi
+
+cutoff_ms=$(( ($(date +%s) - RETAIN_HOURS * 3600) * 1000 ))
+log_echo "=== rotate-api-logs dir=$LOG_DIR_TARGET retain_hours=$RETAIN_HOURS ==="
+
+shopt -s nullglob
+for f in "$LOG_DIR_TARGET"/*.log; do
+  size=$(wc -c <"$f" | tr -d ' ')
+
+  # Oversized files are truncated outright rather than filtered: parsing hundreds
+  # of MB line by line costs more than the history is worth.
+  if (( size > MAX_BYTES )); then
+    : >"$f"
+    log_echo "truncated (was $size bytes, over ${MAX_BYTES}): $(basename "$f")"
+    continue
+  fi
+
+  # Keep pino JSON lines newer than the cutoff. Lines without a parseable "time"
+  # (plain console.log output) are dropped, since they cannot be dated and are
+  # the noisiest part of the file.
+  kept="$(mktemp)"
+  awk -v cutoff="$cutoff_ms" '
+    match($0, /"time":[0-9]+/) {
+      t = substr($0, RSTART + 7, RLENGTH - 7) + 0
+      if (t >= cutoff) print
+    }
+  ' "$f" >"$kept" 2>/dev/null || true
+
+  new_size=$(wc -c <"$kept" | tr -d ' ')
+  cat "$kept" >"$f"
+  rm -f "$kept"
+  log_echo "trimmed $(basename "$f"): $size -> $new_size bytes"
+done
+
+log_echo "=== rotate-api-logs done ==="
+trim_log

--- a/scripts/rotate-api-logs.sh
+++ b/scripts/rotate-api-logs.sh
@@ -2,11 +2,11 @@
 #
 # Trim the PM2 app logs to a short retention window.
 #
-# PM2 does not rotate logs on its own, so include/.pm2/logs grew to 640MB across
-# two files, the oldest entries dating to 2025. Anything logged lives forever
-# until someone notices — which is how ~1,300 subscriber emails ended up sitting
-# on disk for a year. Keep the window short so a future logging mistake has a
-# bounded blast radius.
+# PM2 does not rotate logs on its own, so the app logs had grown to hundreds of
+# megabytes with entries going back more than a year. Anything logged lives until
+# someone notices, which is how PII from a since-fixed logging bug stayed on disk
+# for so long. Keep the window short so a future logging mistake has a bounded
+# blast radius.
 #
 # Truncates in place with `: >` rather than deleting: PM2 holds the file open, so
 # unlinking it would leave the daemon writing to an invisible inode until restart.


### PR DESCRIPTION
Two independent bugs let healthcheck-api.sh report green over a dead or dying
ac-api. Both were just fixed for listmonk; this ports them to the site host.

No systemd scope. May First runs scheduled jobs as Type=oneshot user units,
which default to KillMode=control-group, so systemd SIGTERMs everything left in
the unit cgroup when the script exits. The PM2 CLI auto-spawns the God daemon on
ANY command, and `pm2 status` was the script's first pm2 call, so the daemon
(and ac-api with it) was adopted into the doomed cgroup: restart, ping green,
then get killed on the way out. ensure_pm2_daemon() now places the daemon in its
own cgroup before any other pm2 command - a transient scope where that is
allowed, falling back to a transient unit on hosts that refuse to migrate a PID
into a scope's cgroup. warn_if_pm2_shares_our_cgroup() logs the condition when
neither works, since it is invisible otherwise.

Gated the ping on `pm2 status` text. "online" only means PM2 has a child it has
not seen exit; it says nothing about whether Fastify bound the port or the routes
registered. The check now also probes the API over HTTP and asserts on the
response BODY, not the status code: handlers here return their result object
rather than setting a status (api/subscribe.js), so Fastify answers HTTP 200 even
on failure and a status-code-only probe would still read green. Verdicts follow
lib/listmonk-roundtrip.sh, with DOWN replacing UPSTREAM_DOWN because an
unreachable API is the service this monitor owns and does warrant a restart;
rate-limited probes stay inconclusive and never trigger one.

The probe targets the loopback port by default - this monitor owns ac-api, not
nginx, and healthcheck-site.sh already covers the public URL.

Tests: __tests__/api-probe.test.js covers classify_api_probe, including the
HTTP-200-on-failure trap, fixed-string marker matching, and each verdict branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API health checks that validate both service status and HTTP responses.
  * Added configurable temporary-directory management and stale temporary-file cleanup.
  * Added PM2 log rotation with configurable retention and size limits.

* **Bug Fixes**
  * Improved secure handling of temporary files and deployment secrets.
  * Redacted sensitive subscriber data, credentials, and health-check URLs from logs.
  * Improved domain health-check redirect handling.

* **Documentation**
  * Documented logging, temporary-file, and API health-check configuration rules.

* **Tests**
  * Added coverage for API probe outcomes and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->