### PR TITLE
Stop deploys from serving old page HTML against the new build's chunks

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -51,6 +51,39 @@ ErrorDocument 404 /404/index.html
 
 ### END GENERATED REDIRECTS ###
 
+# Caching. Two buckets, split on whether a URL's bytes can ever change.
+#
+#   /_next/static/*  Every filename carries a content hash, so a given URL is
+#                    immutable — cache it for a year. This is also what lets a
+#                    visitor who already holds a chunk keep using it while a
+#                    deploy swaps the _next/ tree underneath them.
+#
+#   HTML             Must never be served from a cache without asking us first.
+#                    Each build rewrites every page with new chunk hashes, so a
+#                    stale HTML file references chunks that no longer exist: the
+#                    page renders and then dies on hydration with a
+#                    ChunkLoadError. Apache sends no Cache-Control of its own,
+#                    which leaves browsers free to invent a freshness lifetime
+#                    (heuristically ~10% of the file's age), so this is not
+#                    hypothetical. "no-cache" still lets the browser store the
+#                    file — it just has to revalidate, which is a cheap 304 for
+#                    as long as the page is unchanged.
+#
+# Matched on the request URI rather than with <FilesMatch> because a request for
+# /proton/ reaches index.html through an internal subrequest (and because
+# <LocationMatch> is not permitted in .htaccess). Directory requests all end in
+# "/" — DirectorySlash redirects /proton to /proton/ — so that suffix plus an
+# explicit .html covers every page. Anything else (images, fonts, files/, rss/)
+# is left alone and keeps the behavior it has today.
+<IfModule mod_setenvif.c>
+  SetEnvIf Request_URI "^/_next/static/" AC_IMMUTABLE_ASSET
+  SetEnvIf Request_URI "(/|\.html)$" AC_HTML_DOC
+</IfModule>
+<IfModule mod_headers.c>
+  Header set Cache-Control "public, max-age=31536000, immutable" env=AC_IMMUTABLE_ASSET
+  Header set Cache-Control "no-cache" env=AC_HTML_DOC
+</IfModule>
+
 # Security Headers
 <IfModule mod_headers.c>
   Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io; media-src 'self'; font-src 'self'; connect-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"

--- a/scripts/build-deploy.sh
+++ b/scripts/build-deploy.sh
@@ -171,6 +171,36 @@ while :; do
   fi
   # Docroot folder for server-only large files (see .rsync-exclude); not from git or out/.
   mkdir -p "$DEPLOY_TARGET/large-assets"
+
+  # Publish in two passes so the docroot is never a new _next/ tree next to old
+  # page HTML.
+  #
+  # rsync walks in byte order and "_next" (0x5F) sorts before every lowercase
+  # page directory (0x61+), so a single --delete pass replaced the chunks and
+  # deleted the old ones seconds-to-tens-of-seconds before it rewrote, say,
+  # proton/index.html — en/, es/, files/ and images/ all copy in between, and a
+  # new build id changes every HTML file, so none of that is a no-op. Anyone
+  # loading a page in that window got the previous build's HTML pointing at
+  # chunks that were already gone: the page rendered, then died on hydration
+  # with a ChunkLoadError.
+  #
+  # Pass 1 lays the new build down beside the old one. Nothing is removed, so
+  # old and new HTML both still have chunks to load. Pass 2 removes what the new
+  # build no longer references, by which point every page on disk is new. It
+  # transfers nothing, so it is quick.
+  log "Publishing pass 1/2 (add and update, no deletes) → $DEPLOY_TARGET"
+  rsync -a "${RSYNC_EXCLUDE[@]}" "$REPO_DIR/out/" "$DEPLOY_TARGET/"
+
+  # A page fetched in the closing moments of pass 1 still has to come back for
+  # its chunks. Hold briefly so those requests land before pass 2 deletes the
+  # old ones. Set DEPLOY_SETTLE_SECONDS=0 to skip.
+  settle="${DEPLOY_SETTLE_SECONDS:-5}"
+  if [[ "$settle" != "0" ]]; then
+    log "Settling ${settle}s so in-flight page loads can finish fetching chunks"
+    sleep "$settle"
+  fi
+
+  log "Publishing pass 2/2 (prune files the new build dropped) → $DEPLOY_TARGET"
   rsync -a --delete "${RSYNC_EXCLUDE[@]}" "$REPO_DIR/out/" "$DEPLOY_TARGET/"
 
   # Post-deploy smoke checks (informational only; deploy already published).

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -36,6 +36,23 @@ if [[ -f "$ROOT/.rsync-exclude" ]]; then
 fi
 # Server-only large files (see .rsync-exclude); create once so uploads have a stable path.
 ensure_remote_large_assets_dir
+
+# Two passes, for the same reason as scripts/build-deploy.sh: rsync sorts _next/
+# ahead of every lowercase page directory, so one --delete pass swaps the chunks
+# and deletes the old ones well before it rewrites the pages that reference them,
+# and requests landing in that window get a ChunkLoadError. Pass 1 adds the new
+# build without removing anything; pass 2 prunes once every page on disk is new.
+echo "===> Publishing pass 1/2 (add and update, no deletes)..."
+rsync -avz "${RSYNC_EXCLUDE[@]}" "$ROOT/out/" "$FTP_USER@$FTP_HOST:$FTP_DIR"
+
+# Let page loads from the tail of pass 1 finish fetching their chunks.
+DEPLOY_SETTLE_SECONDS="${DEPLOY_SETTLE_SECONDS:-5}"
+if [[ "$DEPLOY_SETTLE_SECONDS" != "0" ]]; then
+  echo "===> Settling ${DEPLOY_SETTLE_SECONDS}s before pruning..."
+  sleep "$DEPLOY_SETTLE_SECONDS"
+fi
+
+echo "===> Publishing pass 2/2 (prune files the new build dropped)..."
 rsync -avz --delete "${RSYNC_EXCLUDE[@]}" "$ROOT/out/" "$FTP_USER@$FTP_HOST:$FTP_DIR"
 
 echo "===> Uploading remote .env.production from $LOCAL_ENV_PRODUCTION_FILE..."


### PR DESCRIPTION
A visitor who loaded /proton/ during a deploy got the page, then a
ChunkLoadError about a second later: the HTML was the previous build's and
pointed at layout-c51103dc761f0c49.js, which the new build had already
deleted. The 404s came back as 404/index.html, hence the "MIME type
('text/html') is not executable" noise, and Next then hard-reloaded.

The window is structural. rsync walks in byte order, so "_next" (0x5F) sorts
ahead of every lowercase page directory (0x61+): a single --delete pass
replaces the chunks and deletes the old ones before it rewrites the pages
that reference them, with en/, es/, files/ and images/ copying in between. A
new build id rewrites every HTML file, so none of that is a skipped no-op.

Publish in two passes instead. Pass one adds the new build without removing
anything, so old and new HTML both still have chunks to load; pass two prunes
what the new build dropped, once every page on disk is new. A short settle
between them (DEPLOY_SETTLE_SECONDS, default 5) lets page loads from the tail
of pass one finish fetching. Both publish paths get this: build-deploy.sh,
which the webhook runs, and deploy-remote.sh for a manual deploy.

Also set the cache headers that make the swap safe on the client. Apache was
sending no Cache-Control at all, so browsers were free to invent a freshness
lifetime for HTML and could serve a stale page long after a deploy finished —
the same crash, on a much wider window. HTML is now no-cache (still stored,
just revalidated, which is a cheap 304), and /_next/static/* is immutable for
a year since those filenames are content hashes.

Matched with SetEnvIf on the request URI, not <FilesMatch>: /proton/ reaches
index.html through an internal subrequest, and <LocationMatch> is not allowed
in .htaccess. trailingSlash is on, so "/" plus an explicit .html covers every
page and leaves images, fonts, files/ and rss/ exactly as they were.
